### PR TITLE
Fix oversized error output

### DIFF
--- a/mistral-ocr.py
+++ b/mistral-ocr.py
@@ -9,6 +9,7 @@ from getpass import getpass
 import glob
 import base64
 import logging
+import json
 from pathlib import Path
 from typing import List, Optional, Tuple
 import mimetypes
@@ -87,6 +88,35 @@ class OCRException(Exception):
     """Raised when the OCR API returns an error."""
 
 
+def _scrub_files(data: object) -> None:
+    """Recursively remove any 'file' keys from *data* if it's a mapping."""
+    if isinstance(data, dict):
+        data.pop("file", None)
+        for value in data.values():
+            _scrub_files(value)
+    elif isinstance(data, list):
+        for item in data:
+            _scrub_files(item)
+
+
+def _summarize_error(data: object) -> str:
+    """Return a short summary for an OCR error payload."""
+    if isinstance(data, dict) and isinstance(data.get("detail"), list):
+        parts = []
+        for item in data["detail"]:
+            if not isinstance(item, dict):
+                continue
+            msg = item.get("msg")
+            loc = item.get("loc")
+            loc_str = "".join([str(x) + "." for x in loc])[:-1] if isinstance(loc, list) else ""
+            if msg and loc_str:
+                parts.append(f"{loc_str}: {msg}")
+            elif msg:
+                parts.append(str(msg))
+        return "; ".join(parts)
+    return ""
+
+
 def extract_text(
     file_path: Path,
     api_key: str,
@@ -115,7 +145,17 @@ def extract_text(
         raise OCRException(f"Network error: {exc}") from exc
 
     if resp.status_code != 200:
-        raise OCRException(f"API error: {resp.status_code} {resp.text}")
+        body = resp.text
+        try:
+            data = resp.json()
+            _scrub_files(data)
+            summary = _summarize_error(data)
+            body = summary or json.dumps(data)
+        except Exception:
+            pass
+        if len(body) > 1000:
+            body = body[:1000] + "... [truncated]"
+        raise OCRException(f"API error: {resp.status_code} {body}")
 
     payload = resp.json()
     text = payload.get("text", "")

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,8 +1,10 @@
 import base64
+import json
 from pathlib import Path
 import importlib.util
 import types
 import sys
+import pytest
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "mistral-ocr.py"
 spec = importlib.util.spec_from_file_location("mocr", MODULE_PATH)
@@ -32,3 +34,59 @@ def test_extract_text_payload(monkeypatch, tmp_path):
     doc = captured['payload']['document']
     assert doc['file'] == base64.b64encode(data).decode()
     assert doc['mime_type'] == 'application/pdf'
+
+
+def test_extract_text_error_truncated(monkeypatch, tmp_path):
+    file = tmp_path / "doc.pdf"
+    file.write_bytes(b"data")
+    encoded = base64.b64encode(b"data").decode()
+
+    payload = {
+        "error": "bad",
+        "document": {"file": encoded, "mime_type": "application/pdf"},
+    }
+
+    class Resp:
+        status_code = 400
+        text = json.dumps(payload)
+
+        def json(self):
+            return payload
+
+    monkeypatch.setattr(mod.requests, "post", lambda *a, **kw: Resp())
+    with pytest.raises(mod.OCRException) as exc:
+        mod.extract_text(file, "k")
+    msg = str(exc.value)
+    assert encoded not in msg
+    assert msg.startswith("API error: 400")
+
+
+def test_extract_text_error_nested(monkeypatch, tmp_path):
+    file = tmp_path / "doc.pdf"
+    file.write_bytes(b"data")
+    encoded = base64.b64encode(b"data").decode()
+
+    payload = {
+        "detail": [
+            {
+                "type": "missing",
+                "loc": ["body", "document"],
+                "msg": "Field required",
+                "input": {"file": encoded},
+            }
+        ]
+    }
+
+    class Resp:
+        status_code = 422
+        text = json.dumps(payload)
+
+        def json(self):
+            return payload
+
+    monkeypatch.setattr(mod.requests, "post", lambda *a, **kw: Resp())
+    with pytest.raises(mod.OCRException) as exc:
+        mod.extract_text(file, "k")
+    msg = str(exc.value)
+    assert encoded not in msg
+    assert "body.document: Field required" in msg


### PR DESCRIPTION
## Summary
- sanitize error responses from the OCR API to remove nested encoded file contents and summarise error messages
- add regression test for nested file data in error payloads

## Testing
- `pip install requests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68474648943483238bd9b76bc843c24b