### PR TITLE
Fix oversized error output

### DIFF
--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,8 +1,10 @@
 import base64
+import json
 from pathlib import Path
 import importlib.util
 import types
 import sys
+import pytest
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "mistral-ocr.py"
 spec = importlib.util.spec_from_file_location("mocr", MODULE_PATH)
@@ -30,5 +32,68 @@ def test_extract_text_payload(monkeypatch, tmp_path):
     monkeypatch.setattr(mod.requests, 'post', fake_post)
     mod.extract_text(file, 'k')
     doc = captured['payload']['document']
-    assert doc['file'] == base64.b64encode(data).decode()
-    assert doc['mime_type'] == 'application/pdf'
+    assert doc['type'] == 'document_url'
+    assert doc['document_url'].startswith('data:application/pdf;base64,')
+    assert doc['document_url'].endswith(base64.b64encode(data).decode())
+
+
+def test_extract_text_error_truncated(monkeypatch, tmp_path):
+    file = tmp_path / "doc.pdf"
+    file.write_bytes(b"data")
+    encoded = base64.b64encode(b"data").decode()
+
+    payload = {
+        "error": "bad",
+        "document": {
+            "type": "document_url",
+            "document_url": f"data:application/pdf;base64,{encoded}",
+        },
+    }
+
+    class Resp:
+        status_code = 400
+        text = json.dumps(payload)
+
+        def json(self):
+            return payload
+
+    monkeypatch.setattr(mod.requests, "post", lambda *a, **kw: Resp())
+    with pytest.raises(mod.OCRException) as exc:
+        mod.extract_text(file, "k")
+    msg = str(exc.value)
+    assert encoded not in msg
+    assert msg.startswith("API error: 400")
+
+
+def test_extract_text_error_nested(monkeypatch, tmp_path):
+    file = tmp_path / "doc.pdf"
+    file.write_bytes(b"data")
+    encoded = base64.b64encode(b"data").decode()
+
+    payload = {
+        "detail": [
+            {
+                "type": "missing",
+                "loc": ["body", "document"],
+                "msg": "Field required",
+                "input": {
+                    "type": "document_url",
+                    "document_url": f"data:application/pdf;base64,{encoded}",
+                },
+            }
+        ]
+    }
+
+    class Resp:
+        status_code = 422
+        text = json.dumps(payload)
+
+        def json(self):
+            return payload
+
+    monkeypatch.setattr(mod.requests, "post", lambda *a, **kw: Resp())
+    with pytest.raises(mod.OCRException) as exc:
+        mod.extract_text(file, "k")
+    msg = str(exc.value)
+    assert encoded not in msg
+    assert "body.document: Field required" in msg


### PR DESCRIPTION
## Summary
- sanitize error responses from the OCR API to remove nested encoded file contents and summarise error messages
- add regression test for nested file data in error payloads
- encode uploaded files as data URLs when calling the OCR API

## Testing
- `pip install requests -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68474648943483238bd9b76bc843c24b