### PR TITLE
Fix model default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Common options:
 - `--api-key` – provide the API key (otherwise read from config or prompted).
 - `--output-format` – `markdown` (default), `text` or `json`.
 - `--language` – optional language hint.
+- `--model` – OCR model to use (defaults to `mistral-ocr-latest`).
 - `--config-path` – path to configuration file (defaults to `~/.mistral_ocr.cfg`).
 
 The configuration file is created automatically if it does not exist and can be

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,15 +15,17 @@ Config = mod.Config
 
 
 def test_parse_args():
-    ns = parse_args(["*.pdf", "--output-format", "text"])
+    ns = parse_args(["*.pdf", "--output-format", "text", "--model", "m"])
     assert ns.patterns == ["*.pdf"]
     assert ns.output_format == "text"
+    assert ns.model == "m"
 
 
 def test_parse_args_default(monkeypatch):
     monkeypatch.setattr(sys, "argv", ["prog", "file.pdf"])
     ns = parse_args(None)
     assert ns.patterns == ["file.pdf"]
+    assert ns.model is None
 
 
 def test_main_success(tmp_path: Path, monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,13 +13,14 @@ spec.loader.exec_module(cfg)
 
 def test_load_and_save_config(tmp_path: Path) -> None:
     path = tmp_path / "conf.cfg"
-    c = cfg.Config(api_key="KEY", output_format="text", language="en")
+    c = cfg.Config(api_key="KEY", output_format="text", language="en", model="m")
     cfg.save_config(c, path)
 
     loaded = cfg.load_config(path)
     assert loaded.api_key == "KEY"
     assert loaded.output_format == "text"
     assert loaded.language == "en"
+    assert loaded.model == "m"
 
 
 def test_ensure_config_template(tmp_path: Path) -> None:
@@ -30,3 +31,4 @@ def test_ensure_config_template(tmp_path: Path) -> None:
     parser.read(path)
     assert parser.has_section("mistral")
     assert parser.get("mistral", "api_key") == ""
+    assert "model" in parser["mistral"]

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,8 +1,10 @@
 import base64
+import json
 from pathlib import Path
 import importlib.util
 import types
 import sys
+import pytest
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "mistral-ocr.py"
 spec = importlib.util.spec_from_file_location("mocr", MODULE_PATH)
@@ -30,5 +32,105 @@ def test_extract_text_payload(monkeypatch, tmp_path):
     monkeypatch.setattr(mod.requests, 'post', fake_post)
     mod.extract_text(file, 'k')
     doc = captured['payload']['document']
-    assert doc['file'] == base64.b64encode(data).decode()
-    assert doc['mime_type'] == 'application/pdf'
+    assert doc['type'] == 'document_url'
+    assert doc['document_url'].startswith('data:application/pdf;base64,')
+    assert doc['document_url'].endswith(base64.b64encode(data).decode())
+    assert captured['payload']['model'] == mod.DEFAULT_MODEL
+
+
+def test_extract_text_error_truncated(monkeypatch, tmp_path):
+    file = tmp_path / "doc.pdf"
+    file.write_bytes(b"data")
+    encoded = base64.b64encode(b"data").decode()
+
+    payload = {
+        "error": "bad",
+        "document": {
+            "type": "document_url",
+            "document_url": f"data:application/pdf;base64,{encoded}",
+        },
+    }
+
+    class Resp:
+        status_code = 400
+        text = json.dumps(payload)
+
+        def json(self):
+            return payload
+
+    monkeypatch.setattr(mod.requests, "post", lambda *a, **kw: Resp())
+    with pytest.raises(mod.OCRException) as exc:
+        mod.extract_text(file, "k")
+    msg = str(exc.value)
+    assert encoded not in msg
+    assert msg.startswith("API error: 400")
+
+
+def test_extract_text_error_nested(monkeypatch, tmp_path):
+    file = tmp_path / "doc.pdf"
+    file.write_bytes(b"data")
+    encoded = base64.b64encode(b"data").decode()
+
+    payload = {
+        "detail": [
+            {
+                "type": "missing",
+                "loc": ["body", "document"],
+                "msg": "Field required",
+                "input": {
+                    "type": "document_url",
+                    "document_url": f"data:application/pdf;base64,{encoded}",
+                },
+            }
+        ]
+    }
+
+    class Resp:
+        status_code = 422
+        text = json.dumps(payload)
+
+        def json(self):
+            return payload
+
+    monkeypatch.setattr(mod.requests, "post", lambda *a, **kw: Resp())
+    with pytest.raises(mod.OCRException) as exc:
+        mod.extract_text(file, "k")
+    msg = str(exc.value)
+    assert encoded not in msg
+    assert "body.document: Field required" in msg
+
+
+def test_extract_text_error_message_detail(monkeypatch, tmp_path):
+    file = tmp_path / "doc.pdf"
+    file.write_bytes(b"data")
+    encoded = base64.b64encode(b"data").decode()
+
+    payload = {
+        "object": "error",
+        "message": {
+            "detail": [
+                {
+                    "type": "missing",
+                    "loc": ["body", "document"],
+                    "msg": "Field required",
+                    "input": {
+                        "document_url": f"data:application/pdf;base64,{encoded}"
+                    },
+                }
+            ]
+        },
+    }
+
+    class Resp:
+        status_code = 422
+        text = json.dumps(payload)
+
+        def json(self):
+            return payload
+
+    monkeypatch.setattr(mod.requests, "post", lambda *a, **kw: Resp())
+    with pytest.raises(mod.OCRException) as exc:
+        mod.extract_text(file, "k")
+    msg = str(exc.value)
+    assert encoded not in msg
+    assert "body.document: Field required" in msg


### PR DESCRIPTION
## Summary
- handle `message.detail` when summarizing API errors so the logs remain concise
- test error parsing with nested `message.detail`

## Testing
- `pip install requests -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68474648943483238bd9b76bc843c24b