### PR TITLE
Add Chrome extension and OCR server

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,30 @@ Run the unit tests with:
 ```
 pytest
 ```
+
+## Chrome Extension
+
+A Chrome extension is provided in the `chrome-extension` directory. It can
+save the current tab or a text selection as a Markdown file using the Mistral
+OCR service when needed.
+
+### Run the local OCR server
+
+```
+pip install flask flask-cors
+python ocr_server.py
+```
+
+### Load the extension
+
+1. Open `chrome://extensions` in Chrome and enable **Developer mode**.
+2. Click **Load unpacked** and select the `chrome-extension` folder.
+3. Right–click a page or selection and choose **Save Page to Markdown** or
+   **Save Selection to Markdown**.
+
+The extension stores your API key locally and communicates only with the
+extension's background service and the local OCR server.
+
+If the page cannot be parsed as HTML (e.g. PDF, image, or office document), the
+extension fetches the complete file and sends it to the local OCR server for
+OCR, ensuring content beyond the visible viewport is processed.

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,0 +1,79 @@
+async function sendMessageWithInjection(tabId, message) {
+  try {
+    return await chrome.tabs.sendMessage(tabId, message);
+  } catch (e) {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      files: ["content.js"],
+    });
+    return await chrome.tabs.sendMessage(tabId, message);
+  }
+}
+
+function storageGet(key) {
+  return new Promise((resolve) => chrome.storage.local.get(key, resolve));
+}
+
+function storageSet(obj) {
+  return new Promise((resolve) => chrome.storage.local.set(obj, resolve));
+}
+
+async function getApiKey(tabId) {
+  const items = await storageGet("api_key");
+  let key = items.api_key;
+  if (!key) {
+    const resp = await sendMessageWithInjection(tabId, { type: "promptApiKey" });
+    key = resp && resp.apiKey ? resp.apiKey : "";
+    if (key) await storageSet({ api_key: key });
+  }
+  return key || "";
+}
+
+async function fetchAndOCR(tab) {
+  const apiKey = await getApiKey(tab.id);
+  const resp = await fetch(tab.url, { credentials: "omit" });
+  const blob = await resp.blob();
+  const arrayBuffer = await blob.arrayBuffer();
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
+  const dataUrl = `data:${blob.type || "application/octet-stream"};base64,${base64}`;
+  const ocrResp = await fetch("http://localhost:5000/ocr", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ file: dataUrl, api_key: apiKey }),
+  });
+  const data = await ocrResp.json();
+  return data.markdown || "";
+}
+
+function downloadMarkdown(markdown, filename) {
+  const blob = new Blob([markdown], { type: "text/markdown" });
+  const url = URL.createObjectURL(blob);
+  chrome.downloads.download({ url, filename, saveAs: true });
+}
+
+function sanitizeFilename(name) {
+  return name.replace(/[^a-z0-9\-]+/gi, "_");
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({ id: "save_page", title: "Save Page to Markdown", contexts: ["page"] });
+  chrome.contextMenus.create({ id: "save_selection", title: "Save Selection to Markdown", contexts: ["selection"] });
+});
+
+chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+  if (!tab || tab.id === undefined) return;
+  const filename = sanitizeFilename(tab.title || "page") + ".md";
+  let response;
+  if (info.menuItemId === "save_selection") {
+    response = await sendMessageWithInjection(tab.id, { type: "getSelection" });
+  } else {
+    response = await sendMessageWithInjection(tab.id, { type: "getPage" });
+  }
+  let markdown = response && response.markdown;
+  if (!markdown || !markdown.trim()) {
+    markdown = await fetchAndOCR(tab);
+  }
+  if (markdown && markdown.trim()) {
+    downloadMarkdown(markdown, filename);
+  }
+});

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,0 +1,80 @@
+function cleanDocument(doc) {
+  ["header", "nav", "footer", "script", "style", "aside", "iframe", "noscript"].forEach((sel) => {
+    doc.querySelectorAll(sel).forEach((el) => el.remove());
+  });
+}
+
+function nodeToMarkdown(node) {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent || "";
+  }
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return "";
+  }
+  const tag = node.tagName.toLowerCase();
+  let content = Array.from(node.childNodes).map(nodeToMarkdown).join("");
+  switch (tag) {
+    case "h1":
+      return "# " + content + "\n\n";
+    case "h2":
+      return "## " + content + "\n\n";
+    case "h3":
+      return "### " + content + "\n\n";
+    case "strong":
+    case "b":
+      return "**" + content + "**";
+    case "em":
+    case "i":
+      return "*" + content + "*";
+    case "p":
+      return content + "\n\n";
+    case "br":
+      return "\n";
+    case "li":
+      return "- " + content + "\n";
+    case "ul":
+    case "ol":
+      return "\n" + content + "\n";
+    case "a":
+      return `[${content}](${node.getAttribute("href") || ""})`;
+    case "img":
+      return `![${node.getAttribute("alt") || ""}](${node.getAttribute("src") || ""})`;
+    default:
+      return content;
+  }
+}
+
+function htmlToMarkdown(html) {
+  const div = document.createElement("div");
+  div.innerHTML = html;
+  return nodeToMarkdown(div);
+}
+
+function getPageMarkdown() {
+  const docClone = document.cloneNode(true);
+  cleanDocument(docClone);
+  const main = docClone.querySelector("main");
+  const target = main || docClone.body;
+  return htmlToMarkdown(target.innerHTML);
+}
+
+function getSelectionMarkdown() {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return "";
+  const range = sel.getRangeAt(0);
+  const div = document.createElement("div");
+  div.appendChild(range.cloneContents());
+  return htmlToMarkdown(div.innerHTML);
+}
+
+chrome.runtime.onMessage.addListener((req, sender, sendResponse) => {
+  if (req.type === "getPage") {
+    sendResponse({ markdown: getPageMarkdown() });
+  } else if (req.type === "getSelection") {
+    sendResponse({ markdown: getSelectionMarkdown() });
+  } else if (req.type === "promptApiKey") {
+    const apiKey = window.prompt("Enter Mistral API key");
+    sendResponse({ apiKey });
+  }
+  return true;
+});

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "Mistral OCR Markdown Saver",
+  "version": "1.0",
+  "description": "Save page or selection to Markdown via Mistral OCR",
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "downloads",
+    "storage",
+    "contextMenus",
+    "tabs"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_title": "Save to Markdown"
+  },
+  "host_permissions": ["<all_urls>"]
+}

--- a/ocr_server.py
+++ b/ocr_server.py
@@ -1,0 +1,44 @@
+"""Simple HTTP server exposing Mistral OCR via /ocr endpoint."""
+
+import base64
+import tempfile
+from pathlib import Path
+import importlib.util
+import sys
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+
+# Dynamically import the existing mistral-ocr.py as a module
+MODULE_PATH = Path(__file__).resolve().parent / "mistral-ocr.py"
+spec = importlib.util.spec_from_file_location("mocr", MODULE_PATH)
+mocr = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = mocr
+assert spec.loader
+spec.loader.exec_module(mocr)
+
+app = Flask(__name__)
+CORS(app)
+
+@app.post("/ocr")
+def ocr():
+    data = request.get_json(force=True)
+    image = data.get("image")
+    file_data = data.get("file")
+    api_key = data.get("api_key")
+    data_url = image or file_data
+    if not data_url or not api_key:
+        return jsonify({"error": "file/image and api_key required"}), 400
+    header, encoded = data_url.split(",", 1) if "," in data_url else ("", data_url)
+    suffix = ".bin"
+    if ";base64" in header and "/" in header:
+        mime = header.split(":", 1)[1].split(";", 1)[0]
+        ext = mocr.mimetypes.guess_extension(mime) or ".bin"
+        suffix = ext
+    fd, temp_path = tempfile.mkstemp(suffix=suffix)
+    Path(temp_path).write_bytes(base64.b64decode(encoded))
+    text, tokens, cost = mocr.extract_text(Path(temp_path), api_key)
+    Path(temp_path).unlink(missing_ok=True)
+    return jsonify({"markdown": text, "tokens": tokens, "cost": cost})
+
+if __name__ == "__main__":
+    app.run(host="127.0.0.1", port=5000)


### PR DESCRIPTION
## Summary
- Use local storage and credentials-free file fetching in Chrome extension to send full-page content to OCR server
- Improve content extraction by targeting `<main>` elements and remove navigation wrappers
- Extend OCR server to accept any file type instead of viewport screenshots

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f67d502808323b308b62ddf8b7ba8