### PR TITLE
Add Chrome extension and OCR server

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,34 @@ Run the unit tests with:
 ```
 pytest
 ```
+
+## Chrome Extension
+
+A Chrome extension is provided in the `chrome-extension` directory. It can
+save the current tab or a text selection as a Markdown file using the Mistral
+OCR service when needed.
+
+### Run the local OCR server
+
+```
+pip install flask flask-cors
+python ocr_server.py
+```
+
+### Load the extension
+
+1. Open `chrome://extensions` in Chrome and enable **Developer mode**.
+2. Click **Load unpacked** and select the `chrome-extension` folder.
+3. Click the extension icon to open the popup. Enter your API key and click
+   **Save API Key**. From the popup you can run **Run Tests** to verify the
+   connection to the content script and local OCR server, and click
+   **Save to Markdown** to save the active tab or current selection.
+4. Right–click a page or selection and choose **Save Page to Markdown** or
+   **Save Selection to Markdown** if you prefer using context menus.
+
+The extension stores your API key locally and communicates only with the
+extension's background service and the local OCR server.
+
+If the page cannot be parsed as HTML (e.g. PDF, image, or office document), the
+extension fetches the complete file and sends it to the local OCR server for
+OCR, ensuring content beyond the visible viewport is processed.

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,0 +1,126 @@
+async function sendMessageWithInjection(tabId, message) {
+  try {
+    return await chrome.tabs.sendMessage(tabId, message);
+  } catch (e) {
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      files: ["content.js"],
+    });
+    return await chrome.tabs.sendMessage(tabId, message);
+  }
+}
+
+function storageGet(key) {
+  return new Promise((resolve) => chrome.storage.local.get(key, resolve));
+}
+
+function storageSet(obj) {
+  return new Promise((resolve) => chrome.storage.local.set(obj, resolve));
+}
+
+async function getApiKey() {
+  const items = await storageGet("api_key");
+  return items.api_key || "";
+}
+
+async function fetchAndOCR(tab) {
+  const apiKey = await getApiKey();
+  const resp = await fetch(tab.url, { credentials: "omit" });
+  const blob = await resp.blob();
+  const arrayBuffer = await blob.arrayBuffer();
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
+  const dataUrl = `data:${blob.type || "application/octet-stream"};base64,${base64}`;
+  const ocrResp = await fetch("http://localhost:5000/ocr", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ file: dataUrl, api_key: apiKey }),
+  });
+  const data = await ocrResp.json();
+  return data.markdown || "";
+}
+
+function downloadMarkdown(markdown, filename) {
+  const blob = new Blob([markdown], { type: "text/markdown" });
+  const url = URL.createObjectURL(blob);
+  chrome.downloads.download({ url, filename, saveAs: true });
+}
+
+function sanitizeFilename(name) {
+  return name.replace(/[^a-z0-9\-]+/gi, "_");
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({ id: "save_page", title: "Save Page to Markdown", contexts: ["page"] });
+  chrome.contextMenus.create({ id: "save_selection", title: "Save Selection to Markdown", contexts: ["selection"] });
+});
+
+async function processTab(tab, preferSelection) {
+  const filename = sanitizeFilename(tab.title || "page") + ".md";
+  let response;
+  if (preferSelection) {
+    response = await sendMessageWithInjection(tab.id, { type: "getSelection" });
+    if (!response || !response.markdown || !response.markdown.trim()) {
+      response = await sendMessageWithInjection(tab.id, { type: "getPage" });
+    }
+  } else {
+    response = await sendMessageWithInjection(tab.id, { type: "getPage" });
+  }
+  let markdown = response && response.markdown;
+  if (!markdown || !markdown.trim()) {
+    markdown = await fetchAndOCR(tab);
+  }
+  if (markdown && markdown.trim()) {
+    downloadMarkdown(markdown, filename);
+  }
+}
+
+chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+  if (!tab || tab.id === undefined) return;
+  await processTab(tab, info.menuItemId === "save_selection");
+});
+
+async function runTests() {
+  const results = [];
+  const apiKey = await getApiKey();
+  results.push(apiKey ? "API key set" : "API key missing");
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (tab && tab.id !== undefined) {
+      const resp = await sendMessageWithInjection(tab.id, { type: "getPage" });
+      if (resp && resp.markdown) {
+        results.push("Content script accessible");
+      } else {
+        results.push("Content script returned empty");
+      }
+    } else {
+      results.push("No active tab");
+    }
+  } catch (e) {
+    results.push("Error accessing tab");
+  }
+  try {
+    const health = await fetch("http://localhost:5000/health");
+    results.push(health.ok ? "OCR server reachable" : "OCR server error");
+  } catch (e) {
+    results.push("OCR server unreachable");
+  }
+  const passed = results.every((r) => !/missing|empty|error|unreachable/.test(r));
+  return { passed, details: results };
+}
+
+chrome.runtime.onMessage.addListener((req, sender, sendResponse) => {
+  if (req.type === "saveTab") {
+    chrome.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
+      const tab = tabs[0];
+      if (tab && tab.id !== undefined) {
+        await processTab(tab, true);
+      }
+      sendResponse({ status: "done" });
+    });
+    return true;
+  }
+  if (req.type === "runTests") {
+    runTests().then(sendResponse);
+    return true;
+  }
+});

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,0 +1,77 @@
+function cleanDocument(doc) {
+  ["header", "nav", "footer", "script", "style", "aside", "iframe", "noscript"].forEach((sel) => {
+    doc.querySelectorAll(sel).forEach((el) => el.remove());
+  });
+}
+
+function nodeToMarkdown(node) {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return node.textContent || "";
+  }
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return "";
+  }
+  const tag = node.tagName.toLowerCase();
+  let content = Array.from(node.childNodes).map(nodeToMarkdown).join("");
+  switch (tag) {
+    case "h1":
+      return "# " + content + "\n\n";
+    case "h2":
+      return "## " + content + "\n\n";
+    case "h3":
+      return "### " + content + "\n\n";
+    case "strong":
+    case "b":
+      return "**" + content + "**";
+    case "em":
+    case "i":
+      return "*" + content + "*";
+    case "p":
+      return content + "\n\n";
+    case "br":
+      return "\n";
+    case "li":
+      return "- " + content + "\n";
+    case "ul":
+    case "ol":
+      return "\n" + content + "\n";
+    case "a":
+      return `[${content}](${node.getAttribute("href") || ""})`;
+    case "img":
+      return `![${node.getAttribute("alt") || ""}](${node.getAttribute("src") || ""})`;
+    default:
+      return content;
+  }
+}
+
+function htmlToMarkdown(html) {
+  const div = document.createElement("div");
+  div.innerHTML = html;
+  return nodeToMarkdown(div);
+}
+
+function getPageMarkdown() {
+  const docClone = document.cloneNode(true);
+  cleanDocument(docClone);
+  const main = docClone.querySelector("main");
+  const target = main || docClone.body;
+  return htmlToMarkdown(target.innerHTML);
+}
+
+function getSelectionMarkdown() {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return "";
+  const range = sel.getRangeAt(0);
+  const div = document.createElement("div");
+  div.appendChild(range.cloneContents());
+  return htmlToMarkdown(div.innerHTML);
+}
+
+chrome.runtime.onMessage.addListener((req, sender, sendResponse) => {
+  if (req.type === "getPage") {
+    sendResponse({ markdown: getPageMarkdown() });
+  } else if (req.type === "getSelection") {
+    sendResponse({ markdown: getSelectionMarkdown() });
+  }
+  return true;
+});

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,22 @@
+{
+  "manifest_version": 3,
+  "name": "Mistral OCR Markdown Saver",
+  "version": "1.0",
+  "description": "Save page or selection to Markdown via Mistral OCR",
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "downloads",
+    "storage",
+    "contextMenus",
+    "tabs"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_title": "Save to Markdown",
+    "default_popup": "popup.html"
+  },
+  "host_permissions": ["<all_urls>"]
+}

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    body { font-family: sans-serif; min-width: 250px; }
+    label { display: block; margin-top: 8px; }
+    input { width: 100%; }
+    button { margin-top: 8px; width: 100%; }
+    #status { margin-top: 8px; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <label>API Key
+    <input type="password" id="apiKey" placeholder="Enter API key" />
+  </label>
+  <button id="saveKey">Save API Key</button>
+  <button id="runTests">Run Tests</button>
+  <button id="saveMarkdown">Save to Markdown</button>
+  <div id="status"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -1,0 +1,34 @@
+function storageGet(key) {
+  return new Promise((resolve) => chrome.storage.local.get(key, resolve));
+}
+
+function storageSet(obj) {
+  return new Promise((resolve) => chrome.storage.local.set(obj, resolve));
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const items = await storageGet('api_key');
+  document.getElementById('apiKey').value = items.api_key || '';
+});
+
+document.getElementById('saveKey').addEventListener('click', async () => {
+  const key = document.getElementById('apiKey').value.trim();
+  await storageSet({ api_key: key });
+  document.getElementById('status').textContent = 'API key saved.';
+});
+
+document.getElementById('runTests').addEventListener('click', () => {
+  const status = document.getElementById('status');
+  status.textContent = 'Running tests...';
+  chrome.runtime.sendMessage({ type: 'runTests' }, (result) => {
+    if (!result) {
+      status.textContent = 'No response from background.';
+      return;
+    }
+    status.textContent = (result.passed ? 'All tests passed' : 'Some tests failed') + '\n' + result.details.join('\n');
+  });
+});
+
+document.getElementById('saveMarkdown').addEventListener('click', () => {
+  chrome.runtime.sendMessage({ type: 'saveTab' });
+});

--- a/ocr_server.py
+++ b/ocr_server.py
@@ -1,0 +1,49 @@
+"""Simple HTTP server exposing Mistral OCR via /ocr endpoint."""
+
+import base64
+import tempfile
+from pathlib import Path
+import importlib.util
+import sys
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+
+# Dynamically import the existing mistral-ocr.py as a module
+MODULE_PATH = Path(__file__).resolve().parent / "mistral-ocr.py"
+spec = importlib.util.spec_from_file_location("mocr", MODULE_PATH)
+mocr = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = mocr
+assert spec.loader
+spec.loader.exec_module(mocr)
+
+app = Flask(__name__)
+CORS(app)
+
+@app.post("/ocr")
+def ocr():
+    data = request.get_json(force=True)
+    image = data.get("image")
+    file_data = data.get("file")
+    api_key = data.get("api_key")
+    data_url = image or file_data
+    if not data_url or not api_key:
+        return jsonify({"error": "file/image and api_key required"}), 400
+    header, encoded = data_url.split(",", 1) if "," in data_url else ("", data_url)
+    suffix = ".bin"
+    if ";base64" in header and "/" in header:
+        mime = header.split(":", 1)[1].split(";", 1)[0]
+        ext = mocr.mimetypes.guess_extension(mime) or ".bin"
+        suffix = ext
+    fd, temp_path = tempfile.mkstemp(suffix=suffix)
+    Path(temp_path).write_bytes(base64.b64decode(encoded))
+    text, tokens, cost = mocr.extract_text(Path(temp_path), api_key)
+    Path(temp_path).unlink(missing_ok=True)
+    return jsonify({"markdown": text, "tokens": tokens, "cost": cost})
+
+
+@app.get("/health")
+def health():
+    return jsonify({"status": "ok"})
+
+if __name__ == "__main__":
+    app.run(host="127.0.0.1", port=5000)


### PR DESCRIPTION
## Summary
- Add popup UI to Chrome extension for API key entry, self-tests, and saving the active tab or selection to Markdown
- Support runtime messages and self-test checks in background script and expose `/health` endpoint on OCR server
- Update README with instructions for using the popup and context menu options

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f67d502808323b308b62ddf8b7ba8