### PR TITLE
Handle missing HTTP deps with built-in fallbacks

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -41,7 +41,10 @@ async function fetchWithRetry(url, options = {}, retries = 2, backoff = 500) {
     try {
       debugLog("fetchWithRetry request", {
         url,
-        options: { ...options, headers: scrubHeaders(options.headers) },
+        options: {
+          ...options,
+          headers: scrubHeaders(options.headers),
+        },
         attempt,
       });
       const controller = new AbortController();
@@ -49,7 +52,18 @@ async function fetchWithRetry(url, options = {}, retries = 2, backoff = 500) {
       const timeoutId = setTimeout(() => controller.abort(), timeout);
       const resp = await fetch(url, { ...options, signal: controller.signal });
       clearTimeout(timeoutId);
-      debugLog("fetchWithRetry response", { url, status: resp.status });
+      const respClone = resp.clone();
+      let body = "";
+      try {
+        body = await respClone.text();
+      } catch (e) {
+        body = "<unreadable>";
+      }
+      debugLog("fetchWithRetry response", {
+        url,
+        status: resp.status,
+        body,
+      });
       if (!resp.ok && attempt < retries && resp.status >= 500) {
         debugLog(`Fetch ${url} failed with status ${resp.status}, retrying...`);
         await new Promise((r) => setTimeout(r, backoff * 2 ** attempt));
@@ -104,7 +118,7 @@ async function getSettings() {
 async function fetchAndOCR(tab, settings) {
   const { apiKey, model, language, format } = settings;
   try {
-  log("Fetching tab for OCR", tab.url);
+    debugLog("Fetching tab for OCR", tab.url);
     const resp = await fetch(tab.url, { credentials: "omit" });
     const blob = await resp.blob();
     const arrayBuffer = await blob.arrayBuffer();
@@ -115,9 +129,10 @@ async function fetchAndOCR(tab, settings) {
       headers["Authorization"] = `Bearer ${apiKey}`;
       headers["X-API-Key"] = apiKey;
     }
-    log("OCR request", {
+    debugLog("OCR request", {
       url: "http://127.0.0.1:5000/ocr",
       headers: scrubHeaders(headers),
+      body: { model, language, format, fileLength: dataUrl.length },
     });
     const ocrResp = await fetchWithRetry(
       "http://127.0.0.1:5000/ocr",
@@ -129,13 +144,21 @@ async function fetchAndOCR(tab, settings) {
       },
       2
     );
-    log("OCR response status", ocrResp.status);
+    const rawBody = await ocrResp.text();
+    debugLog("OCR response raw", { status: ocrResp.status, body: rawBody });
     if (!ocrResp.ok) {
-      log("OCR error body", await ocrResp.text());
       return "";
     }
-    const data = await ocrResp.json();
-    return data.text || data.markdown || "";
+    let data;
+    try {
+      data = JSON.parse(rawBody);
+    } catch (e) {
+      errorLog("Failed to parse OCR response", e);
+      return "";
+    }
+    const result = data.text || data.markdown || "";
+    debugLog("OCR result", result);
+    return result;
   } catch (e) {
     errorLog("OCR request failed", e);
     return "";
@@ -197,8 +220,10 @@ async function processTab(tab, preferSelection) {
     if (format === "text" && content) {
       content = markdownToText(content);
     }
-    if (content && content.trim()) {
-      return await downloadContent(content, filename, format);
+  if (content && content.trim()) {
+      const ok = await downloadContent(content, filename, format);
+      debugLog("downloadContent result", { ok, filename, format });
+      return ok;
     }
   } catch (e) {
     errorLog("Processing tab failed", e);

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -6,6 +6,8 @@
     body { font-family: sans-serif; min-width: 250px; }
     label { display: block; margin-top: 8px; }
     input { width: 100%; }
+    input[type="checkbox"] { width: auto; margin-right: 4px; }
+    label.inline { display: flex; align-items: center; }
     button { margin-top: 8px; width: 100%; }
     #status { margin-top: 8px; white-space: pre-wrap; }
   </style>
@@ -17,8 +19,9 @@
   <label>Model
     <input type="text" id="model" placeholder="mistral-ocr-latest" />
   </label>
-  <label>Language
-    <input type="text" id="language" placeholder="optional language hint" />
+  <label>Language (optional)
+    <input type="text" id="language" placeholder="e.g., en, fr, zh" />
+    <small>Optional language hint like "en" for English. Leave blank to autodetect.</small>
   </label>
   <label>Output Format
     <select id="format">
@@ -28,9 +31,9 @@
     </select>
   </label>
   <button id="saveSettings">Save Settings</button>
-  <label><input type="checkbox" id="debug" /> Enable debug logging</label>
+  <label class="inline"><input type="checkbox" id="debug" />Enable debug logging</label>
   <button id="runTests">Run Tests</button>
-  <button id="saveMarkdown">Save</button>
+  <button id="saveMarkdown">Save tab contents as...</button>
   <div id="status"></div>
   <div id="version" style="margin-top:8px;color:#666;font-size:smaller"></div>
   <script src="popup.js"></script>

--- a/compat_requests.py
+++ b/compat_requests.py
@@ -1,0 +1,39 @@
+import json as _json
+from urllib import request as _request, error as _error
+
+class RequestException(Exception):
+    """Exception raised for network errors in compat_requests."""
+
+class Response:
+    """Minimal response object with requests-like interface."""
+
+    def __init__(self, status, body, headers):
+        self.status_code = status
+        self._body = body
+        self.headers = headers
+
+    @property
+    def text(self):
+        return self._body.decode('utf-8')
+
+    def json(self):
+        return _json.loads(self.text)
+
+def _do_request(method: str, url: str, *, headers=None, data=None, timeout=60) -> Response:
+    req = _request.Request(url, data=data, headers=headers or {}, method=method)
+    try:
+        with _request.urlopen(req, timeout=timeout) as resp:
+            return Response(resp.getcode(), resp.read(), resp.headers)
+    except _error.URLError as exc:  # pragma: no cover - network failure
+        raise RequestException(str(exc)) from exc
+
+def post(url: str, headers=None, json=None, timeout: float = 60) -> Response:
+    hdrs = dict(headers or {})
+    data = None
+    if json is not None:
+        data = _json.dumps(json).encode('utf-8')
+        hdrs.setdefault('Content-Type', 'application/json')
+    return _do_request('POST', url, headers=hdrs, data=data, timeout=timeout)
+
+def get(url: str, headers=None, timeout: float = 60) -> Response:
+    return _do_request('GET', url, headers=headers, data=None, timeout=timeout)

--- a/mistral-ocr.py
+++ b/mistral-ocr.py
@@ -14,7 +14,18 @@ import time
 from pathlib import Path
 from typing import List, Optional, Tuple
 import mimetypes
-import requests
+
+try:  # pragma: no cover - optional dependency
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback when requests isn't installed
+    import importlib.util, sys
+    _compat_path = Path(__file__).with_name("compat_requests.py")
+    _spec = importlib.util.spec_from_file_location("compat_requests", _compat_path)
+    compat_requests = importlib.util.module_from_spec(_spec)
+    sys.modules[_spec.name] = compat_requests
+    assert _spec.loader
+    _spec.loader.exec_module(compat_requests)  # type: ignore
+    requests = compat_requests  # type: ignore
 
 
 # ----------------------------- Configuration -----------------------------

--- a/ocr_server.py
+++ b/ocr_server.py
@@ -8,9 +8,28 @@ import sys
 import argparse
 import logging
 import time
-import requests
-from flask import Flask, request, jsonify
-from flask_cors import CORS
+
+try:  # pragma: no cover - optional dependency
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback when requests isn't installed
+    _compat_path = Path(__file__).with_name("compat_requests.py")
+    _spec = importlib.util.spec_from_file_location("compat_requests", _compat_path)
+    compat_requests = importlib.util.module_from_spec(_spec)
+    sys.modules[_spec.name] = compat_requests
+    assert _spec.loader
+    _spec.loader.exec_module(compat_requests)  # type: ignore
+    requests = compat_requests  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from flask import Flask, request, jsonify  # type: ignore
+    from flask_cors import CORS  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - allow import without flask
+    Flask = None  # type: ignore[assignment]
+    request = None  # type: ignore[assignment]
+    def jsonify(obj):  # type: ignore[override]
+        raise ModuleNotFoundError("flask not installed")
+    def CORS(app):  # type: ignore
+        raise ModuleNotFoundError("flask not installed")
 
 # Dynamically import the existing mistral-ocr.py as a module
 MODULE_PATH = Path(__file__).resolve().parent / "mistral-ocr.py"
@@ -24,87 +43,92 @@ parser = argparse.ArgumentParser(description="Mistral OCR server")
 parser.add_argument("--debug", action="store_true", help="Enable debug logging")
 args, _ = parser.parse_known_args()
 
-app = Flask(__name__)
-CORS(app)
+app = Flask(__name__) if Flask is not None else None
+if Flask is not None:
+    CORS(app)
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG, format="mistralocr: %(message)s")
+        app.logger.setLevel(logging.DEBUG)
+    else:
+        logging.basicConfig(format="mistralocr: %(message)s")
 
-if args.debug:
-    logging.basicConfig(level=logging.DEBUG, format="mistralocr: %(message)s")
-    app.logger.setLevel(logging.DEBUG)
+if app is not None:
+    @app.post("/ocr")
+    def ocr():
+        data = request.get_json(force=True)
+        image = data.get("image")
+        file_data = data.get("file")
+        model = data.get("model")
+        language = data.get("language")
+        output_format = data.get("format", "markdown")
+        # Accept API key via JSON or Authorization header (fall back to X-API-Key for backward compatibility)
+        api_key = data.get("api_key") or request.headers.get("X-API-Key")
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            api_key = auth_header[7:]
+        if args.debug:
+            masked = (api_key[:4] + "...") if api_key else "None"
+            app.logger.debug("OCR request headers: %s", dict(request.headers))
+            app.logger.debug("API key provided: %s", masked)
+        data_url = image or file_data
+        if not data_url or not api_key:
+            return jsonify({"error": "file/image and api_key required"}), 400
+        header, encoded = data_url.split(",", 1) if "," in data_url else ("", data_url)
+        suffix = ".bin"
+        if ";base64" in header and "/" in header:
+            mime = header.split(":", 1)[1].split(";", 1)[0]
+            ext = mocr.mimetypes.guess_extension(mime) or ".bin"
+            suffix = ext
+        fd, temp_path = tempfile.mkstemp(suffix=suffix)
+        Path(temp_path).write_bytes(base64.b64decode(encoded))
+        try:
+            text, tokens, cost = _extract_with_retry(
+                Path(temp_path),
+                api_key,
+                model=model,
+                language=language,
+                output_format=output_format,
+            )
+        except mocr.OCRException as exc:
+            app.logger.error("OCR failed: %s", exc)
+            status = 401 if "401" in str(exc) else 403 if "403" in str(exc) else 502
+            return jsonify({"error": str(exc)}), status
+        except Exception as exc:  # pragma: no cover - unexpected
+            app.logger.exception("Unexpected OCR failure: %s", exc)
+            return jsonify({"error": "internal error"}), 500
+        finally:
+            Path(temp_path).unlink(missing_ok=True)
+        resp = {"text": text, "tokens": tokens, "cost": cost}
+        if output_format == "markdown":
+            resp["markdown"] = text
+        return jsonify(resp)
+
+    @app.get("/health")
+    def health():
+        api_key = request.headers.get("X-API-Key")
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            api_key = auth_header[7:]
+        if args.debug:
+            masked = (api_key[:4] + "...") if api_key else "None"
+            app.logger.debug("Health check, api key: %s", masked)
+        if not api_key:
+            return jsonify({"status": "missing api key"}), 401
+        headers = {"Authorization": f"Bearer {api_key}"}
+        try:
+            resp = requests.get("https://api.mistral.ai/v1/models", headers=headers, timeout=5)
+            if resp.status_code == 200:
+                return jsonify({"status": "ok"})
+            app.logger.error("Health upstream failure: %s %s", resp.status_code, resp.text)
+            return jsonify({"status": "unauthorized"}), resp.status_code
+        except Exception as exc:  # pragma: no cover - network issues
+            app.logger.error("Health check error: %s", exc)
+            return jsonify({"status": "upstream error"}), 502
 else:
-    logging.basicConfig(format="mistralocr: %(message)s")
-
-@app.post("/ocr")
-def ocr():
-    data = request.get_json(force=True)
-    image = data.get("image")
-    file_data = data.get("file")
-    model = data.get("model")
-    language = data.get("language")
-    output_format = data.get("format", "markdown")
-    # Accept API key via JSON or Authorization header (fall back to X-API-Key for backward compatibility)
-    api_key = data.get("api_key") or request.headers.get("X-API-Key")
-    auth_header = request.headers.get("Authorization", "")
-    if auth_header.startswith("Bearer "):
-        api_key = auth_header[7:]
-    if args.debug:
-        masked = (api_key[:4] + "...") if api_key else "None"
-        app.logger.debug("OCR request headers: %s", dict(request.headers))
-        app.logger.debug("API key provided: %s", masked)
-    data_url = image or file_data
-    if not data_url or not api_key:
-        return jsonify({"error": "file/image and api_key required"}), 400
-    header, encoded = data_url.split(",", 1) if "," in data_url else ("", data_url)
-    suffix = ".bin"
-    if ";base64" in header and "/" in header:
-        mime = header.split(":", 1)[1].split(";", 1)[0]
-        ext = mocr.mimetypes.guess_extension(mime) or ".bin"
-        suffix = ext
-    fd, temp_path = tempfile.mkstemp(suffix=suffix)
-    Path(temp_path).write_bytes(base64.b64decode(encoded))
-    try:
-        text, tokens, cost = _extract_with_retry(
-            Path(temp_path),
-            api_key,
-            model=model,
-            language=language,
-            output_format=output_format,
-        )
-    except mocr.OCRException as exc:
-        app.logger.error("OCR failed: %s", exc)
-        status = 401 if "401" in str(exc) else 403 if "403" in str(exc) else 502
-        return jsonify({"error": str(exc)}), status
-    except Exception as exc:  # pragma: no cover - unexpected
-        app.logger.exception("Unexpected OCR failure: %s", exc)
-        return jsonify({"error": "internal error"}), 500
-    finally:
-        Path(temp_path).unlink(missing_ok=True)
-    resp = {"text": text, "tokens": tokens, "cost": cost}
-    if output_format == "markdown":
-        resp["markdown"] = text
-    return jsonify(resp)
-
-
-@app.get("/health")
-def health():
-    api_key = request.headers.get("X-API-Key")
-    auth_header = request.headers.get("Authorization", "")
-    if auth_header.startswith("Bearer "):
-        api_key = auth_header[7:]
-    if args.debug:
-        masked = (api_key[:4] + "...") if api_key else "None"
-        app.logger.debug("Health check, api key: %s", masked)
-    if not api_key:
-        return jsonify({"status": "missing api key"}), 401
-    headers = {"Authorization": f"Bearer {api_key}"}
-    try:
-        resp = requests.get("https://api.mistral.ai/v1/models", headers=headers, timeout=5)
-        if resp.status_code == 200:
-            return jsonify({"status": "ok"})
-        app.logger.error("Health upstream failure: %s %s", resp.status_code, resp.text)
-        return jsonify({"status": "unauthorized"}), resp.status_code
-    except Exception as exc:  # pragma: no cover - network issues
-        app.logger.error("Health check error: %s", exc)
-        return jsonify({"status": "upstream error"}), 502
+    def ocr():  # type: ignore
+        raise ModuleNotFoundError("flask not installed")
+    def health():  # type: ignore
+        raise ModuleNotFoundError("flask not installed")
 
 
 def _extract_with_retry(


### PR DESCRIPTION
## Summary
- provide a minimal `compat_requests` module so the CLI and server can run without the external requests package
- load Flask conditionally in the OCR server to avoid import errors when the library is missing
- add verbose debug logging that records every request, response, and result when enabled
- clarify extension popup UI by explaining optional language hints, aligning the debug checkbox, and renaming the save button

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f9c1cadd08323b76dcd454a46a2ce