### PR TITLE
Handle missing HTTP deps with built-in fallbacks

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -76,7 +76,6 @@ chrome.runtime.onMessage.addListener((req, sender, sendResponse) => {
   } else if (req.type === "getSelection") {
     sendResponse({ markdown: getSelectionMarkdown() });
   }
-  return true;
 });
 
 //# sourceURL=content.js

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -6,6 +6,8 @@
     body { font-family: sans-serif; min-width: 250px; }
     label { display: block; margin-top: 8px; }
     input { width: 100%; }
+    input[type="checkbox"] { width: auto; margin-right: 4px; }
+    label.inline { display: flex; align-items: center; }
     button { margin-top: 8px; width: 100%; }
     #status { margin-top: 8px; white-space: pre-wrap; }
   </style>
@@ -17,8 +19,9 @@
   <label>Model
     <input type="text" id="model" placeholder="mistral-ocr-latest" />
   </label>
-  <label>Language
-    <input type="text" id="language" placeholder="optional language hint" />
+  <label>Language (optional)
+    <input type="text" id="language" placeholder="e.g., en, fr, zh" />
+    <small>Optional language hint like "en" for English. Leave blank to autodetect.</small>
   </label>
   <label>Output Format
     <select id="format">
@@ -28,9 +31,9 @@
     </select>
   </label>
   <button id="saveSettings">Save Settings</button>
-  <label><input type="checkbox" id="debug" /> Enable debug logging</label>
+  <label class="inline"><input type="checkbox" id="debug" />Enable debug logging</label>
   <button id="runTests">Run Tests</button>
-  <button id="saveMarkdown">Save</button>
+  <button id="saveMarkdown">Save tab contents as...</button>
   <div id="status"></div>
   <div id="version" style="margin-top:8px;color:#666;font-size:smaller"></div>
   <script src="popup.js"></script>

--- a/compat_requests.py
+++ b/compat_requests.py
@@ -1,0 +1,39 @@
+import json as _json
+from urllib import request as _request, error as _error
+
+class RequestException(Exception):
+    """Exception raised for network errors in compat_requests."""
+
+class Response:
+    """Minimal response object with requests-like interface."""
+
+    def __init__(self, status, body, headers):
+        self.status_code = status
+        self._body = body
+        self.headers = headers
+
+    @property
+    def text(self):
+        return self._body.decode('utf-8')
+
+    def json(self):
+        return _json.loads(self.text)
+
+def _do_request(method: str, url: str, *, headers=None, data=None, timeout=60) -> Response:
+    req = _request.Request(url, data=data, headers=headers or {}, method=method)
+    try:
+        with _request.urlopen(req, timeout=timeout) as resp:
+            return Response(resp.getcode(), resp.read(), resp.headers)
+    except _error.URLError as exc:  # pragma: no cover - network failure
+        raise RequestException(str(exc)) from exc
+
+def post(url: str, headers=None, json=None, timeout: float = 60) -> Response:
+    hdrs = dict(headers or {})
+    data = None
+    if json is not None:
+        data = _json.dumps(json).encode('utf-8')
+        hdrs.setdefault('Content-Type', 'application/json')
+    return _do_request('POST', url, headers=hdrs, data=data, timeout=timeout)
+
+def get(url: str, headers=None, timeout: float = 60) -> Response:
+    return _do_request('GET', url, headers=headers, data=None, timeout=timeout)

--- a/mistral-ocr.py
+++ b/mistral-ocr.py
@@ -14,7 +14,18 @@ import time
 from pathlib import Path
 from typing import List, Optional, Tuple
 import mimetypes
-import requests
+
+try:  # pragma: no cover - optional dependency
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback when requests isn't installed
+    import importlib.util, sys
+    _compat_path = Path(__file__).with_name("compat_requests.py")
+    _spec = importlib.util.spec_from_file_location("compat_requests", _compat_path)
+    compat_requests = importlib.util.module_from_spec(_spec)
+    sys.modules[_spec.name] = compat_requests
+    assert _spec.loader
+    _spec.loader.exec_module(compat_requests)  # type: ignore
+    requests = compat_requests  # type: ignore
 
 
 # ----------------------------- Configuration -----------------------------
@@ -132,6 +143,53 @@ def _summarize_error(data: object) -> str:
     return ""
 
 
+def _prepare_request(
+    file_path: Path,
+    api_key: str,
+    model: str,
+    language: Optional[str],
+) -> tuple[dict, dict]:
+    """Build request headers and payload for the OCR API."""
+    logging.debug("Preparing request for %s", file_path)
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "X-API-Key": api_key,
+    }
+    masked = (api_key[:4] + "...") if api_key else "None"
+    logging.debug("Using API key: %s", masked)
+    with open(file_path, "rb") as fh:
+        encoded = base64.b64encode(fh.read()).decode()
+    mime, _ = mimetypes.guess_type(file_path)
+    if mime is None:
+        mime = "application/octet-stream"
+    data_url = f"data:{mime};base64,{encoded}"
+    if mime.startswith("image/"):
+        document = {"type": "image_url", "image_url": {"url": data_url}}
+    else:
+        document = {"type": "document_url", "document_url": data_url}
+    payload: dict = {"document": document, "model": model}
+    if language:
+        payload["language"] = language
+    payload_log = json.loads(json.dumps(payload))  # deep copy
+    _scrub_files(payload_log)
+    logging.debug("Request headers: %s", {k: (v if k != "Authorization" else v[:10] + "...") for k, v in headers.items()})
+    logging.debug("Request payload: %s", payload_log)
+    return headers, payload
+
+
+def _send_request(headers: dict, payload: dict) -> "requests.Response":
+    """Send the OCR request and log the full exchange."""
+    logging.debug("POST %s", API_URL)
+    resp = requests.post(API_URL, headers=headers, json=payload, timeout=60)
+    logging.debug("Response status: %s", resp.status_code)
+    try:
+        logging.debug("Response headers: %s", dict(resp.headers))
+    except Exception:  # pragma: no cover - headers may be missing
+        pass
+    logging.debug("Response body: %s", resp.text)
+    return resp
+
+
 def extract_text(
     file_path: Path,
     api_key: str,
@@ -142,32 +200,12 @@ def extract_text(
     backoff: float = 1.0,
 ) -> Tuple[str, int, float]:
     """Extract text from *file_path* using the Mistral OCR API."""
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "X-API-Key": api_key,
-    }
-    with open(file_path, "rb") as fh:
-        encoded = base64.b64encode(fh.read()).decode()
-
-
-        mime, _ = mimetypes.guess_type(file_path)
-    if mime is None:
-        mime = "application/octet-stream"
-
-    data_url = f"data:{mime};base64,{encoded}"
-    if mime.startswith("image/"):
-        document = {"type": "image_url", "image_url": {"url": data_url}}
-    else:
-        document = {"type": "document_url", "document_url": data_url}
-
-    payload = {"document": document, "model": model}
-    if language:
-        payload["language"] = language
+    headers, payload = _prepare_request(file_path, api_key, model, language)
 
     last_exc: Exception | None = None
     for attempt in range(retries + 1):
         try:
-            resp = requests.post(API_URL, headers=headers, json=payload, timeout=60)
+            resp = _send_request(headers, payload)
             break
         except requests.RequestException as exc:  # pragma: no cover - network issues
             last_exc = exc


### PR DESCRIPTION
## Summary
- provide a minimal `compat_requests` module so the CLI and server can run without the external requests package
- load Flask conditionally in the OCR server to avoid import errors when the library is missing
- add verbose debug logging that records every request, response, and result when enabled
- clarify extension popup UI by explaining optional language hints, aligning the debug checkbox, and renaming the save button
- log OCR authorization in discrete steps for easier debugging and retry reporting
- remove incorrect async flag in the content script to prevent message-channel warnings and redundant injections
- trim `fetchWithRetry` to only clone and parse responses when debug logging is enabled and log failures after script injection
- ensure background listeners always respond even on errors to avoid message-channel closures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f9c1cadd08323b76dcd454a46a2ce