### PR TITLE
Add API and middleware tests to extension

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -18,5 +18,9 @@
     "default_title": "Save to Markdown",
     "default_popup": "popup.html"
   },
-  "host_permissions": ["http://127.0.0.1/*", "http://localhost/*"]
+  "host_permissions": [
+    "http://127.0.0.1/*",
+    "http://localhost/*",
+    "https://api.mistral.ai/*"
+  ]
 }


### PR DESCRIPTION
## Summary
- extend extension runTests to verify direct Mistral API access, authorization, and model listing
- check middleware can forward model requests and log responses
- allow extension to call Mistral API by adding host permission
- clarify test diagnostics for API headers, endpoint, and middleware authorization
- ensure middleware checks send only Authorization headers to avoid proxying API key

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890a846500c8323887468de711e3179