### PR TITLE
Fix CORS rejection in middleware server

### DIFF
--- a/ocr_server.py
+++ b/ocr_server.py
@@ -22,14 +22,23 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when requests isn't i
 
 try:  # pragma: no cover - optional dependency
     from flask import Flask, request, jsonify  # type: ignore
-    from flask_cors import CORS  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - allow import without flask
     Flask = None  # type: ignore[assignment]
     request = None  # type: ignore[assignment]
+
     def jsonify(obj):  # type: ignore[override]
         raise ModuleNotFoundError("flask not installed")
-    def CORS(app):  # type: ignore
-        raise ModuleNotFoundError("flask not installed")
+
+# ``flask_cors`` is optional.  In some environments it rejects the
+# ``chrome-extension://`` origin used by the browser extension which results
+# in confusing 403 responses.  To keep behaviour consistent we do not depend
+# on its origin checks and instead add the CORS headers manually further
+# below.  Importing here is only for backward compatibility when the package
+# is installed; failure to import is harmless.
+try:  # pragma: no cover - optional dependency
+    from flask_cors import CORS  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    CORS = None  # type: ignore[assignment]
 
 # Dynamically import the existing mistral-ocr.py as a module
 MODULE_PATH = Path(__file__).resolve().parent / "mistral-ocr.py"
@@ -45,12 +54,46 @@ args, _ = parser.parse_known_args()
 
 app = Flask(__name__) if Flask is not None else None
 if Flask is not None:
-    CORS(app)
     if args.debug:
         logging.basicConfig(level=logging.DEBUG, format="mistralocr: %(message)s")
     else:
         logging.basicConfig(level=logging.INFO, format="mistralocr: %(message)s")
     app.logger.setLevel(logging.getLogger().level)
+
+    # Add very permissive CORS headers so the browser extension can talk to
+    # the server regardless of its origin.  This replaces the behaviour of
+    # ``flask_cors`` which can reject unknown schemes such as
+    # ``chrome-extension://``.
+    @app.after_request
+    def _add_cors_headers(resp):
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Headers"] = (
+            "Authorization,Content-Type,X-API-Key"
+        )
+        resp.headers["Access-Control-Allow-Methods"] = "GET,POST,OPTIONS"
+        return resp
+
+    @app.before_request
+    def _handle_options():
+        if request.method == "OPTIONS":
+            # A minimal response is enough for browsers to continue the
+            # request.  Headers are added by ``_add_cors_headers`` above.
+            return "", 204
+
+    def _get_api_key(data: dict | None = None) -> str | None:
+        """Extract API key from JSON payload or headers.
+
+        The browser extension may send the key via JSON body, the
+        ``Authorization`` header or the legacy ``X-API-Key`` header.  This
+        helper consolidates the logic so all endpoints behave consistently.
+        """
+
+        if data and (key := data.get("api_key")):
+            return key
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            return auth_header[7:]
+        return request.headers.get("X-API-Key")
 
 if app is not None:
     @app.post("/ocr")
@@ -61,11 +104,7 @@ if app is not None:
         model = data.get("model")
         language = data.get("language")
         output_format = data.get("format", "markdown")
-        # Accept API key via JSON or Authorization header (fall back to X-API-Key for backward compatibility)
-        api_key = data.get("api_key") or request.headers.get("X-API-Key")
-        auth_header = request.headers.get("Authorization", "")
-        if auth_header.startswith("Bearer "):
-            api_key = auth_header[7:]
+        api_key = _get_api_key(data)
         if args.debug:
             masked = (api_key[:4] + "...") if api_key else "None"
             app.logger.debug("OCR request headers: %s", dict(request.headers))
@@ -105,10 +144,7 @@ if app is not None:
 
     @app.get("/health")
     def health():
-        api_key = request.headers.get("X-API-Key")
-        auth_header = request.headers.get("Authorization", "")
-        if auth_header.startswith("Bearer "):
-            api_key = auth_header[7:]
+        api_key = _get_api_key()
         masked = (api_key[:4] + "...") if api_key else "None"
         app.logger.info("Health check, api key: %s", masked)
         if not api_key:
@@ -139,16 +175,13 @@ if app is not None:
         Propagates Authorization and X-API-Key headers from the client and logs
         the upstream response when running with --debug to aid troubleshooting.
         """
-        api_key = request.headers.get("X-API-Key")
-        auth_header = request.headers.get("Authorization", "")
-        if auth_header.startswith("Bearer "):
-            api_key = auth_header[7:]
-        headers = {}
-        if api_key:
-            headers = {
-                "Authorization": f"Bearer {api_key}",
-                "X-API-Key": api_key,
-            }
+        api_key = _get_api_key()
+        if not api_key:
+            return jsonify({"error": "missing api key"}), 401
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "X-API-Key": api_key,
+        }
         url = f"https://api.mistral.ai/v1/{path}"
         try:
             if request.method == "GET":

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,25 @@
+import pytest
+import importlib.util
+import sys
+from pathlib import Path
+
+# Import the server module without requiring it to be on PYTHONPATH.
+MODULE_PATH = Path(__file__).resolve().parents[1] / "ocr_server.py"
+spec = importlib.util.spec_from_file_location("ocr_server", MODULE_PATH)
+server = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = server
+assert spec.loader
+spec.loader.exec_module(server)
+
+pytestmark = pytest.mark.skipif(server.app is None, reason="Flask not installed")
+
+
+def test_health_allows_extension_origin():
+    client = server.app.test_client()
+    resp = client.get('/health', headers={'Origin': 'chrome-extension://abc'})
+    # Missing API key should yield 401 but still include permissive CORS headers
+    assert resp.status_code == 401
+    assert resp.headers.get('Access-Control-Allow-Origin') == '*'
+    allow_headers = resp.headers.get('Access-Control-Allow-Headers', '')
+    assert 'Authorization' in allow_headers
+    assert 'X-API-Key' in allow_headers

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,22 @@
+import pytest
+import importlib.util
+import sys
+from pathlib import Path
+
+# Import server module
+MODULE_PATH = Path(__file__).resolve().parents[1] / "ocr_server.py"
+spec = importlib.util.spec_from_file_location("ocr_server", MODULE_PATH)
+server = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = server
+assert spec.loader
+spec.loader.exec_module(server)
+
+pytestmark = pytest.mark.skipif(server.app is None, reason="Flask not installed")
+
+
+def test_proxy_missing_api_key_returns_401():
+    client = server.app.test_client()
+    resp = client.get('/v1/models')
+    assert resp.status_code == 401
+    assert resp.get_json()['error'] == 'missing api key'
+    assert resp.headers.get('Access-Control-Allow-Origin') == '*'


### PR DESCRIPTION
## Summary
- ensure `ocr_server` always sends permissive CORS headers and handles preflight requests
- add regression test covering CORS headers when requesting `/health`
- refactor middleware to centralize API key handling and return 401 for missing keys
- add test verifying proxy endpoint rejects requests without an API key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890dc1f837083238e517f16c34e80fa