### PR TITLE
Fix middleware auth and CORS handling

### DIFF
--- a/ocr_server.py
+++ b/ocr_server.py
@@ -22,14 +22,23 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when requests isn't i
 
 try:  # pragma: no cover - optional dependency
     from flask import Flask, request, jsonify  # type: ignore
-    from flask_cors import CORS  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - allow import without flask
     Flask = None  # type: ignore[assignment]
     request = None  # type: ignore[assignment]
+
     def jsonify(obj):  # type: ignore[override]
         raise ModuleNotFoundError("flask not installed")
-    def CORS(app):  # type: ignore
-        raise ModuleNotFoundError("flask not installed")
+
+# ``flask_cors`` is optional.  In some environments it rejects the
+# ``chrome-extension://`` origin used by the browser extension which results
+# in confusing 403 responses.  To keep behaviour consistent we do not depend
+# on its origin checks and instead add the CORS headers manually further
+# below.  Importing here is only for backward compatibility when the package
+# is installed; failure to import is harmless.
+try:  # pragma: no cover - optional dependency
+    from flask_cors import CORS  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    CORS = None  # type: ignore[assignment]
 
 # Dynamically import the existing mistral-ocr.py as a module
 MODULE_PATH = Path(__file__).resolve().parent / "mistral-ocr.py"
@@ -45,12 +54,74 @@ args, _ = parser.parse_known_args()
 
 app = Flask(__name__) if Flask is not None else None
 if Flask is not None:
-    CORS(app)
     if args.debug:
         logging.basicConfig(level=logging.DEBUG, format="mistralocr: %(message)s")
     else:
         logging.basicConfig(level=logging.INFO, format="mistralocr: %(message)s")
     app.logger.setLevel(logging.getLogger().level)
+
+    # Add very permissive CORS headers so the browser extension can talk to
+    # the server regardless of its origin.  This replaces the behaviour of
+    # ``flask_cors`` which can reject unknown schemes such as
+    # ``chrome-extension://``.
+    @app.after_request
+    def _add_cors_headers(resp):
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Headers"] = (
+            "Authorization,Content-Type,X-API-Key"
+        )
+        resp.headers["Access-Control-Allow-Methods"] = "GET,POST,OPTIONS"
+        return resp
+
+    @app.before_request
+    def _handle_options():
+        if request.method == "OPTIONS":
+            # A minimal response is enough for browsers to continue the
+            # request.  Headers are added by ``_add_cors_headers`` above.
+            return "", 204
+
+    def _get_api_key(data: dict | None = None) -> str | None:
+        """Extract API key from JSON payload or headers.
+
+        The browser extension may send the key via JSON body, the
+        ``Authorization`` header or the legacy ``X-API-Key`` header.  This
+        helper consolidates the logic so all endpoints behave consistently.
+        """
+
+        if data and (key := data.get("api_key")):
+            return key.strip() or None
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            return auth_header[7:].strip() or None
+        key = request.headers.get("X-API-Key")
+        return key.strip() if key else None
+
+    # Default headers emulate a regular browser request.  The Mistral API can
+    # return 403 if these are missing entirely, so the middleware injects
+    # sensible values when the client omits them.
+    DEFAULT_ORIGIN = "https://api.mistral.ai"
+    DEFAULT_REFERER = DEFAULT_ORIGIN + "/"
+    DEFAULT_UA = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    )
+
+    def _build_upstream_headers(api_key: str) -> dict[str, str]:
+        """Return headers forwarded to the Mistral API.
+
+        ``requests`` sends a very distinctive default ``User-Agent`` and omits
+        ``Origin``/``Referer``.  Some environments interpret this as an
+        automated script and respond with ``403``.  To mirror the extension's
+        behaviour we always send browser-like defaults but still honour any
+        headers explicitly provided by the client.
+        """
+
+        headers = {"Authorization": f"Bearer {api_key}", "X-API-Key": api_key}
+        headers["Origin"] = request.headers.get("Origin", DEFAULT_ORIGIN)
+        headers["Referer"] = request.headers.get("Referer", DEFAULT_REFERER)
+        headers["User-Agent"] = request.headers.get("User-Agent", DEFAULT_UA)
+        return headers
 
 if app is not None:
     @app.post("/ocr")
@@ -61,11 +132,7 @@ if app is not None:
         model = data.get("model")
         language = data.get("language")
         output_format = data.get("format", "markdown")
-        # Accept API key via JSON or Authorization header (fall back to X-API-Key for backward compatibility)
-        api_key = data.get("api_key") or request.headers.get("X-API-Key")
-        auth_header = request.headers.get("Authorization", "")
-        if auth_header.startswith("Bearer "):
-            api_key = auth_header[7:]
+        api_key = _get_api_key(data)
         if args.debug:
             masked = (api_key[:4] + "...") if api_key else "None"
             app.logger.debug("OCR request headers: %s", dict(request.headers))
@@ -105,18 +172,18 @@ if app is not None:
 
     @app.get("/health")
     def health():
-        api_key = request.headers.get("X-API-Key")
-        auth_header = request.headers.get("Authorization", "")
-        if auth_header.startswith("Bearer "):
-            api_key = auth_header[7:]
+        api_key = _get_api_key()
         masked = (api_key[:4] + "...") if api_key else "None"
         app.logger.info("Health check, api key: %s", masked)
         if not api_key:
             return jsonify({"status": "missing api key"}), 401
-        headers = {"Authorization": f"Bearer {api_key}", "X-API-Key": api_key}
+        headers = _build_upstream_headers(api_key)
         try:
             resp = requests.get(
-                "https://api.mistral.ai/v1/models", headers=headers, timeout=5
+                "https://api.mistral.ai/v1/models",
+                headers=headers,
+                timeout=5,
+                proxies={},
             )
             snippet = resp.text[:200]
             app.logger.info(
@@ -139,23 +206,23 @@ if app is not None:
         Propagates Authorization and X-API-Key headers from the client and logs
         the upstream response when running with --debug to aid troubleshooting.
         """
-        api_key = request.headers.get("X-API-Key")
-        auth_header = request.headers.get("Authorization", "")
-        if auth_header.startswith("Bearer "):
-            api_key = auth_header[7:]
-        headers = {}
-        if api_key:
-            headers = {
-                "Authorization": f"Bearer {api_key}",
-                "X-API-Key": api_key,
-            }
+        api_key = _get_api_key()
+        if not api_key:
+            return jsonify({"error": "missing api key"}), 401
+        headers = _build_upstream_headers(api_key)
         url = f"https://api.mistral.ai/v1/{path}"
         try:
             if request.method == "GET":
-                upstream = requests.get(url, headers=headers, timeout=10)
+                upstream = requests.get(
+                    url, headers=headers, timeout=10, proxies={}
+                )
             else:
                 upstream = requests.post(
-                    url, data=request.get_data(), headers=headers, timeout=10
+                    url,
+                    data=request.get_data(),
+                    headers=headers,
+                    timeout=10,
+                    proxies={},
                 )
             masked = (api_key[:4] + "...") if api_key else "None"
             snippet = upstream.text[:200]

--- a/tests/test_api_key_forwarding.py
+++ b/tests/test_api_key_forwarding.py
@@ -1,0 +1,30 @@
+import importlib.util
+import sys
+from pathlib import Path
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / 'ocr_server.py'
+spec = importlib.util.spec_from_file_location('ocr_server', MODULE_PATH)
+server = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = server
+assert spec.loader
+spec.loader.exec_module(server)
+
+pytestmark = pytest.mark.skipif(server.app is None, reason="Flask not installed")
+
+def test_api_key_whitespace_is_trimmed(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers, timeout, proxies):
+        captured['headers'] = headers
+        class Resp:
+            status_code = 200
+            text = 'ok'
+        return Resp()
+
+    monkeypatch.setattr(server.requests, 'get', fake_get)
+    client = server.app.test_client()
+    resp = client.get('/health', headers={'Authorization': 'Bearer test\n\t '})
+    assert resp.status_code == 200
+    assert captured['headers']['Authorization'] == 'Bearer test'
+    assert captured['headers']['X-API-Key'] == 'test'

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,104 @@
+import pytest
+import importlib.util
+import sys
+from pathlib import Path
+
+# Import the server module without requiring it to be on PYTHONPATH.
+MODULE_PATH = Path(__file__).resolve().parents[1] / "ocr_server.py"
+spec = importlib.util.spec_from_file_location("ocr_server", MODULE_PATH)
+server = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = server
+assert spec.loader
+spec.loader.exec_module(server)
+
+pytestmark = pytest.mark.skipif(server.app is None, reason="Flask not installed")
+
+
+def test_health_allows_extension_origin():
+    client = server.app.test_client()
+    resp = client.get('/health', headers={'Origin': 'chrome-extension://abc'})
+    # Missing API key should yield 401 but still include permissive CORS headers
+    assert resp.status_code == 401
+    assert resp.headers.get('Access-Control-Allow-Origin') == '*'
+    allow_headers = resp.headers.get('Access-Control-Allow-Headers', '')
+    assert 'Authorization' in allow_headers
+    assert 'X-API-Key' in allow_headers
+
+
+def test_health_forwards_origin_header(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers, timeout, proxies):
+        captured['headers'] = headers
+        class Resp:
+            status_code = 200
+            text = 'ok'
+        return Resp()
+
+    monkeypatch.setattr(server.requests, 'get', fake_get)
+    client = server.app.test_client()
+    origin = 'chrome-extension://abc'
+    resp = client.get(
+        '/health',
+        headers={
+            'Authorization': 'Bearer test',
+            'X-API-Key': 'test',
+            'Origin': origin,
+            'Referer': origin,
+        },
+    )
+    assert resp.status_code == 200
+    assert captured['headers']['Origin'] == origin
+    assert captured['headers']['Referer'] == origin
+
+
+def test_health_injects_defaults_when_missing(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers, timeout, proxies):
+        captured['headers'] = headers
+        class Resp:
+            status_code = 200
+            text = 'ok'
+        return Resp()
+
+    monkeypatch.setattr(server.requests, 'get', fake_get)
+    client = server.app.test_client()
+    resp = client.get(
+        '/health',
+        headers={'Authorization': 'Bearer test', 'X-API-Key': 'test'},
+    )
+    assert resp.status_code == 200
+    assert captured['headers']['Origin'] == server.DEFAULT_ORIGIN
+    assert captured['headers']['Referer'] == server.DEFAULT_REFERER
+    assert captured['headers']['User-Agent'] == server.DEFAULT_UA
+
+
+def test_health_disables_system_proxies(monkeypatch):
+    called = {}
+
+    def fake_get(url, headers, timeout, proxies):
+        called['proxies'] = proxies
+        class Resp:
+            status_code = 200
+            text = 'ok'
+        return Resp()
+
+    monkeypatch.setattr(server.requests, 'get', fake_get)
+    client = server.app.test_client()
+    resp = client.get(
+        '/health',
+        headers={'Authorization': 'Bearer test', 'X-API-Key': 'test'},
+    )
+    assert resp.status_code == 200
+    assert called['proxies'] == {}
+
+
+def test_options_preflight_returns_cors_headers():
+    client = server.app.test_client()
+    resp = client.options('/health', headers={'Origin': 'chrome-extension://abc'})
+    assert resp.status_code == 204
+    assert resp.headers.get('Access-Control-Allow-Origin') == '*'
+    allow_headers = resp.headers.get('Access-Control-Allow-Headers', '')
+    assert 'Authorization' in allow_headers
+    assert 'X-API-Key' in allow_headers

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,107 @@
+import pytest
+import importlib.util
+import sys
+from pathlib import Path
+
+# Import server module
+MODULE_PATH = Path(__file__).resolve().parents[1] / "ocr_server.py"
+spec = importlib.util.spec_from_file_location("ocr_server", MODULE_PATH)
+server = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = server
+assert spec.loader
+spec.loader.exec_module(server)
+
+pytestmark = pytest.mark.skipif(server.app is None, reason="Flask not installed")
+
+
+def test_proxy_missing_api_key_returns_401():
+    client = server.app.test_client()
+    resp = client.get('/v1/models')
+    assert resp.status_code == 401
+    assert resp.get_json()['error'] == 'missing api key'
+    assert resp.headers.get('Access-Control-Allow-Origin') == '*'
+
+
+def test_proxy_forwards_origin_header(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers, timeout, proxies):
+        captured['headers'] = headers
+        class Resp:
+            status_code = 200
+            text = '{}'
+            headers = {}
+            content = b'{}'
+        return Resp()
+
+    monkeypatch.setattr(server.requests, 'get', fake_get)
+    client = server.app.test_client()
+    origin = 'chrome-extension://abc'
+    resp = client.get(
+        '/v1/models',
+        headers={
+            'Authorization': 'Bearer test',
+            'X-API-Key': 'test',
+            'Origin': origin,
+            'Referer': origin,
+        },
+    )
+    assert resp.status_code == 200
+    assert captured['headers']['Origin'] == origin
+    assert captured['headers']['Referer'] == origin
+
+
+def test_proxy_injects_defaults_when_missing(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers, timeout, proxies):
+        captured['headers'] = headers
+        class Resp:
+            status_code = 200
+            text = '{}'
+            headers = {}
+            content = b'{}'
+        return Resp()
+
+    monkeypatch.setattr(server.requests, 'get', fake_get)
+    client = server.app.test_client()
+    resp = client.get(
+        '/v1/models',
+        headers={'Authorization': 'Bearer test', 'X-API-Key': 'test'},
+    )
+    assert resp.status_code == 200
+    assert captured['headers']['Origin'] == server.DEFAULT_ORIGIN
+    assert captured['headers']['Referer'] == server.DEFAULT_REFERER
+    assert captured['headers']['User-Agent'] == server.DEFAULT_UA
+
+
+def test_proxy_disables_system_proxies(monkeypatch):
+    called = {}
+
+    def fake_get(url, headers, timeout, proxies):
+        called['proxies'] = proxies
+        class Resp:
+            status_code = 200
+            text = '{}'
+            headers = {}
+            content = b'{}'
+        return Resp()
+
+    monkeypatch.setattr(server.requests, 'get', fake_get)
+    client = server.app.test_client()
+    resp = client.get(
+        '/v1/models',
+        headers={'Authorization': 'Bearer test', 'X-API-Key': 'test'},
+    )
+    assert resp.status_code == 200
+    assert called['proxies'] == {}
+
+
+def test_proxy_options_preflight_returns_cors_headers():
+    client = server.app.test_client()
+    resp = client.options('/v1/models')
+    assert resp.status_code == 204
+    assert resp.headers.get('Access-Control-Allow-Origin') == '*'
+    allow_headers = resp.headers.get('Access-Control-Allow-Headers', '')
+    assert 'Authorization' in allow_headers
+    assert 'X-API-Key' in allow_headers


### PR DESCRIPTION
## Summary
- Trim surrounding whitespace from API keys before forwarding to upstream
- Bypass system proxies in middleware requests
- Add preflight CORS handling and regression tests for headers and proxies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890dc1f837083238e517f16c34e80fa