### PR TITLE
Fix middleware auth and CORS handling

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -32,8 +32,11 @@ function log(...args) {
 }
 
 function errorLog(...args) {
-  console.error("mistralocr:", ...args);
-  forwardConsole("error", args);
+  const serialised = args.map((a) =>
+    typeof a === "object" ? JSON.stringify(a) : a
+  );
+  console.error("mistralocr:", ...serialised);
+  forwardConsole("error", serialised);
 }
 
 function debugLog(...args) {

--- a/ocr_server.py
+++ b/ocr_server.py
@@ -22,14 +22,23 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when requests isn't i
 
 try:  # pragma: no cover - optional dependency
     from flask import Flask, request, jsonify  # type: ignore
-    from flask_cors import CORS  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - allow import without flask
     Flask = None  # type: ignore[assignment]
     request = None  # type: ignore[assignment]
+
     def jsonify(obj):  # type: ignore[override]
         raise ModuleNotFoundError("flask not installed")
-    def CORS(app):  # type: ignore
-        raise ModuleNotFoundError("flask not installed")
+
+# ``flask_cors`` is optional.  In some environments it rejects the
+# ``chrome-extension://`` origin used by the browser extension which results
+# in confusing 403 responses.  To keep behaviour consistent we do not depend
+# on its origin checks and instead add the CORS headers manually further
+# below.  Importing here is only for backward compatibility when the package
+# is installed; failure to import is harmless.
+try:  # pragma: no cover - optional dependency
+    from flask_cors import CORS  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    CORS = None  # type: ignore[assignment]
 
 # Dynamically import the existing mistral-ocr.py as a module
 MODULE_PATH = Path(__file__).resolve().parent / "mistral-ocr.py"
@@ -45,12 +54,73 @@ args, _ = parser.parse_known_args()
 
 app = Flask(__name__) if Flask is not None else None
 if Flask is not None:
-    CORS(app)
     if args.debug:
         logging.basicConfig(level=logging.DEBUG, format="mistralocr: %(message)s")
     else:
         logging.basicConfig(level=logging.INFO, format="mistralocr: %(message)s")
     app.logger.setLevel(logging.getLogger().level)
+
+    # Add very permissive CORS headers so the browser extension can talk to
+    # the server regardless of its origin.  This replaces the behaviour of
+    # ``flask_cors`` which can reject unknown schemes such as
+    # ``chrome-extension://``.
+    @app.after_request
+    def _add_cors_headers(resp):
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        resp.headers["Access-Control-Allow-Headers"] = (
+            "Authorization,Content-Type,X-API-Key"
+        )
+        resp.headers["Access-Control-Allow-Methods"] = "GET,POST,OPTIONS"
+        return resp
+
+    @app.before_request
+    def _handle_options():
+        if request.method == "OPTIONS":
+            # A minimal response is enough for browsers to continue the
+            # request.  Headers are added by ``_add_cors_headers`` above.
+            return "", 204
+
+    def _get_api_key(data: dict | None = None) -> str | None:
+        """Extract API key from JSON payload or headers.
+
+        The browser extension may send the key via JSON body, the
+        ``Authorization`` header or the legacy ``X-API-Key`` header.  This
+        helper consolidates the logic so all endpoints behave consistently.
+        """
+
+        if data and (key := data.get("api_key")):
+            return key.strip() or None
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            return auth_header[7:].strip() or None
+        key = request.headers.get("X-API-Key")
+        return key.strip() if key else None
+
+    def _build_upstream_headers(api_key: str) -> dict[str, str]:
+        """Return a minimal set of headers for upstream requests.
+
+        Forwarding every header from the browser turned out to be brittle:
+        some security services compare values such as ``User-Agent`` or the
+        various ``Sec-*`` hints against the TLS fingerprint of the request and
+        return ``403`` if they do not match the expected browser profile.  To
+        avoid these false positives the proxy now sends only a conservative set
+        of headers required by the API.
+
+        ``Authorization`` is rebuilt from the parsed key to guarantee the
+        correct format and ``X-API-Key`` is forwarded for compatibility.  When
+        the client provides ``Accept`` or ``Content-Type`` headers they are
+        relayed as they legitimately influence the response.  Everything else is
+        intentionally dropped.
+        """
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "X-API-Key": api_key,
+        }
+        for name in ("Accept", "Content-Type"):
+            if value := request.headers.get(name):
+                headers[name] = value
+        return headers
 
 if app is not None:
     @app.post("/ocr")
@@ -61,11 +131,7 @@ if app is not None:
         model = data.get("model")
         language = data.get("language")
         output_format = data.get("format", "markdown")
-        # Accept API key via JSON or Authorization header (fall back to X-API-Key for backward compatibility)
-        api_key = data.get("api_key") or request.headers.get("X-API-Key")
-        auth_header = request.headers.get("Authorization", "")
-        if auth_header.startswith("Bearer "):
-            api_key = auth_header[7:]
+        api_key = _get_api_key(data)
         if args.debug:
             masked = (api_key[:4] + "...") if api_key else "None"
             app.logger.debug("OCR request headers: %s", dict(request.headers))
@@ -105,18 +171,18 @@ if app is not None:
 
     @app.get("/health")
     def health():
-        api_key = request.headers.get("X-API-Key")
-        auth_header = request.headers.get("Authorization", "")
-        if auth_header.startswith("Bearer "):
-            api_key = auth_header[7:]
+        api_key = _get_api_key()
         masked = (api_key[:4] + "...") if api_key else "None"
         app.logger.info("Health check, api key: %s", masked)
         if not api_key:
             return jsonify({"status": "missing api key"}), 401
-        headers = {"Authorization": f"Bearer {api_key}", "X-API-Key": api_key}
+        headers = _build_upstream_headers(api_key)
         try:
             resp = requests.get(
-                "https://api.mistral.ai/v1/models", headers=headers, timeout=5
+                "https://api.mistral.ai/v1/models",
+                headers=headers,
+                timeout=5,
+                proxies={},
             )
             snippet = resp.text[:200]
             app.logger.info(
@@ -127,7 +193,10 @@ if app is not None:
             app.logger.error(
                 "Health upstream failure: %s %s", resp.status_code, snippet
             )
-            return jsonify({"status": "unauthorized"}), resp.status_code
+            return (
+                jsonify({"status": "unauthorized", "body": snippet}),
+                resp.status_code,
+            )
         except Exception as exc:  # pragma: no cover - network issues
             app.logger.error("Health check error: %s", exc)
             return jsonify({"status": "upstream error"}), 502
@@ -139,24 +208,22 @@ if app is not None:
         Propagates Authorization and X-API-Key headers from the client and logs
         the upstream response when running with --debug to aid troubleshooting.
         """
-        api_key = request.headers.get("X-API-Key")
-        auth_header = request.headers.get("Authorization", "")
-        if auth_header.startswith("Bearer "):
-            api_key = auth_header[7:]
-        headers = {}
-        if api_key:
-            headers = {
-                "Authorization": f"Bearer {api_key}",
-                "X-API-Key": api_key,
-            }
+        api_key = _get_api_key()
+        if not api_key:
+            return jsonify({"error": "missing api key"}), 401
+        headers = _build_upstream_headers(api_key)
         url = f"https://api.mistral.ai/v1/{path}"
         try:
-            if request.method == "GET":
-                upstream = requests.get(url, headers=headers, timeout=10)
-            else:
-                upstream = requests.post(
-                    url, data=request.get_data(), headers=headers, timeout=10
-                )
+            method = request.method.lower()
+            req_func = getattr(requests, method)
+            upstream = req_func(
+                url,
+                params=request.args,
+                data=request.get_data(),
+                headers=headers,
+                timeout=10,
+                proxies={},
+            )
             masked = (api_key[:4] + "...") if api_key else "None"
             snippet = upstream.text[:200]
             app.logger.info(
@@ -167,6 +234,11 @@ if app is not None:
                 upstream.status_code,
                 snippet,
             )
+            if upstream.status_code in {401, 403} and not upstream.content:
+                return (
+                    jsonify({"error": "unauthorized", "body": snippet}),
+                    upstream.status_code,
+                )
             return (
                 upstream.content,
                 upstream.status_code,

--- a/tests/test_api_key_forwarding.py
+++ b/tests/test_api_key_forwarding.py
@@ -1,0 +1,30 @@
+import importlib.util
+import sys
+from pathlib import Path
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / 'ocr_server.py'
+spec = importlib.util.spec_from_file_location('ocr_server', MODULE_PATH)
+server = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = server
+assert spec.loader
+spec.loader.exec_module(server)
+
+pytestmark = pytest.mark.skipif(server.app is None, reason="Flask not installed")
+
+def test_api_key_whitespace_is_trimmed(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers, timeout, proxies):
+        captured['headers'] = headers
+        class Resp:
+            status_code = 200
+            text = 'ok'
+        return Resp()
+
+    monkeypatch.setattr(server.requests, 'get', fake_get)
+    client = server.app.test_client()
+    resp = client.get('/health', headers={'Authorization': 'Bearer   test  '})
+    assert resp.status_code == 200
+    assert captured['headers']['Authorization'] == 'Bearer test'
+    assert captured['headers']['X-API-Key'] == 'test'

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,85 @@
+import pytest
+import importlib.util
+import sys
+from pathlib import Path
+
+# Import the server module without requiring it to be on PYTHONPATH.
+MODULE_PATH = Path(__file__).resolve().parents[1] / "ocr_server.py"
+spec = importlib.util.spec_from_file_location("ocr_server", MODULE_PATH)
+server = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = server
+assert spec.loader
+spec.loader.exec_module(server)
+
+pytestmark = pytest.mark.skipif(server.app is None, reason="Flask not installed")
+
+
+def test_health_allows_extension_origin():
+    client = server.app.test_client()
+    resp = client.get('/health', headers={'Origin': 'chrome-extension://abc'})
+    # Missing API key should yield 401 but still include permissive CORS headers
+    assert resp.status_code == 401
+    assert resp.headers.get('Access-Control-Allow-Origin') == '*'
+    allow_headers = resp.headers.get('Access-Control-Allow-Headers', '')
+    assert 'Authorization' in allow_headers
+    assert 'X-API-Key' in allow_headers
+
+
+def test_health_strips_sensitive_headers(monkeypatch):
+    captured = {}
+
+    def fake_get(url, headers, timeout, proxies):
+        captured['headers'] = headers
+        class Resp:
+            status_code = 200
+            text = 'ok'
+        return Resp()
+
+    monkeypatch.setattr(server.requests, 'get', fake_get)
+    client = server.app.test_client()
+    origin = 'chrome-extension://abc'
+    resp = client.get(
+        '/health',
+        headers={
+            'Authorization': 'Bearer test',
+            'X-API-Key': 'test',
+            'Origin': origin,
+            'Referer': origin,
+            'User-Agent': 'tester',
+        },
+    )
+    assert resp.status_code == 200
+    assert captured['headers'] == {
+        'Authorization': 'Bearer test',
+        'X-API-Key': 'test',
+    }
+
+
+def test_health_disables_system_proxies(monkeypatch):
+    called = {}
+
+    def fake_get(url, headers, timeout, proxies):
+        called['proxies'] = proxies
+        class Resp:
+            status_code = 200
+            text = 'ok'
+        return Resp()
+
+    monkeypatch.setattr(server.requests, 'get', fake_get)
+    client = server.app.test_client()
+    resp = client.get(
+        '/health',
+        headers={'Authorization': 'Bearer test', 'X-API-Key': 'test'},
+    )
+    assert resp.status_code == 200
+    assert called['proxies'] == {}
+
+
+def test_options_preflight_returns_cors_headers():
+    client = server.app.test_client()
+    resp = client.options('/health', headers={'Origin': 'chrome-extension://abc'})
+    assert resp.status_code == 204
+    assert resp.headers.get('Access-Control-Allow-Origin') == '*'
+    allow_headers = resp.headers.get('Access-Control-Allow-Headers', '')
+    assert 'Authorization' in allow_headers
+    assert 'X-API-Key' in allow_headers


### PR DESCRIPTION
## Summary
- Trim header forwarding to only auth and content-negotiation headers to avoid upstream 403s
- Use method-specific HTTP functions for proxy requests to work without `requests.request`
- Add regression tests validating sensitive headers are stripped and API keys are sanitized

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890dc1f837083238e517f16c34e80fa