### PR TITLE
Remove local middleware and call Mistral API directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,39 +32,26 @@ A Chrome extension is provided in the `chrome-extension` directory. It can
 save the current tab or a text selection as a file using the Mistral
 OCR service when needed. Markdown, plain text, and JSON outputs are supported.
 
-### Run the local OCR server
-
-```
-pip install flask flask-cors
-python ocr_server.py
-```
-
-The server listens on `http://127.0.0.1:5000`, which the extension uses for
-health checks and OCR requests. The extension transmits the API key only via an
-`Authorization: Bearer` header. The `/health` endpoint validates the key by
-querying the Mistral API's model listing, returning `401`/`403` when the key is
-missing or rejected.
-
 ### Load the extension
 
 1. Open `chrome://extensions` in Chrome and enable **Developer mode**.
 2. Click **Load unpacked** and select the `chrome-extension` folder.
-3. Click the extension icon to open the popup. Enter your API key, preferred
-   model, optional language hint, and desired output format, then click
-   **Save Settings**. The popup shows the extension version at the bottom.
+3. Click the extension icon to open the popup. Enter your API key, optional
+   language hint, desired output format, and (optionally) a model. If no model
+   is specified, the extension uses `mistral-ocr-latest`. Click **Save Settings**
+   when done. The popup shows the extension version at the bottom.
    From the popup you can run **Run Tests** to verify the connection to the
-   content script and local OCR server, and click **Save tab contents as...** to
+   content script and Mistral API, and click **Save tab contents as...** to
    save the active tab or current selection.
 4. Right–click a page or selection and choose **Save Page** or
    **Save Selection** if you prefer using context menus.
 
 The extension stores your API key locally along with the selected model,
-language hint, and output format, and communicates only with the extension's
-background service and the local OCR server.
+language hint, and output format, and communicates only with the Mistral API.
 
 If the page cannot be parsed as HTML (e.g. PDF, image, or office document), the
-extension fetches the complete file and sends it to the local OCR server for
-OCR, ensuring content beyond the visible viewport is processed.
+extension fetches the complete file and sends it to the Mistral OCR API,
+ensuring content beyond the visible viewport is processed.
 
 All configurable options of the OCR API (currently the model and language hint)
 are available in the popup so the user can tailor requests without editing
@@ -74,9 +61,6 @@ source files.
 
 Open the extension popup to enable **Enable debug logging**. When enabled, the
 background service outputs verbose logs (view them via `chrome://extensions`
-→ **Service worker**). The **Run Tests** button now reports separate checks for
-the API key, content script, server reachability, and authorization so it is
-clear which step failed.
-
-Run the OCR server with `python ocr_server.py --debug` to see request headers
-and other diagnostic information.
+→ **Service worker**). The **Run Tests** button reports separate checks for
+the API key, content script, and authorization so it is clear which step
+failed.

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -162,14 +162,15 @@ async function getSettings() {
   const items = await storageGet(["api_key", "model", "language", "format"]);
   return {
     apiKey: items.api_key || "",
-    model: items.model || "",
+    // default to latest model if none stored
+    model: items.model || "mistral-ocr-latest",
     language: items.language || "",
     format: items.format || "markdown",
   };
 }
 
 async function fetchAndOCR(tab, settings) {
-  const { apiKey, model, language, format } = settings;
+  const { apiKey, model, language } = settings;
   try {
     debugLog("Fetching tab for OCR", tab.url);
     const resp = await fetch(tab.url, { credentials: "omit" });
@@ -177,22 +178,26 @@ async function fetchAndOCR(tab, settings) {
     const arrayBuffer = await blob.arrayBuffer();
     const base64 = btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
     const dataUrl = `data:${blob.type || "application/octet-stream"};base64,${base64}`;
-    const headers = { "Content-Type": "application/json" };
-    if (apiKey) {
-      headers["Authorization"] = `Bearer ${apiKey}`;
-      headers["X-API-Key"] = apiKey;
+    const headers = buildAuthHeaders(apiKey, true);
+    headers["Content-Type"] = "application/json";
+    const document = blob.type.startsWith("image/")
+      ? { type: "image_url", image_url: { url: dataUrl } }
+      : { type: "document_url", document_url: dataUrl };
+    const body = { document, model: model || "mistral-ocr-latest" };
+    if (language) {
+      body.language = language;
     }
     debugLog("OCR request", {
-      url: "http://127.0.0.1:5000/ocr",
+      url: "https://api.mistral.ai/v1/ocr",
       headers: scrubHeaders(headers),
-      body: { model, language, format, fileLength: dataUrl.length },
+      body: { ...body, document: "<omitted>" },
     });
     const ocrResp = await fetchWithRetry(
-      "http://127.0.0.1:5000/ocr",
+      "https://api.mistral.ai/v1/ocr",
       {
         method: "POST",
         headers,
-        body: JSON.stringify({ file: dataUrl, model, language, format }),
+        body: JSON.stringify(body),
         timeout: 15000,
       },
       2
@@ -209,7 +214,15 @@ async function fetchAndOCR(tab, settings) {
       errorLog("Failed to parse OCR response", e);
       return "";
     }
-    const result = data.text || data.markdown || "";
+    let result = "";
+    if (Array.isArray(data.pages)) {
+      result = data.pages
+        .map((p) => p.markdown || p.text || "")
+        .join("\n\n");
+    }
+    if (!result) {
+      result = data.text || data.markdown || "";
+    }
     debugLog("OCR result", result);
     return result;
   } catch (e) {
@@ -304,13 +317,17 @@ async function runTests() {
     if (tab && tab.id !== undefined) {
       const resp = await sendMessageWithInjection(tab.id, { type: "getPage" });
       debugLog("runTests: content script response", resp);
-      if (resp && resp.markdown) {
-        results.push("Content script accessible");
+      if (resp && typeof resp.markdown === "string") {
         contentOk = true;
+        if (resp.markdown) {
+          results.push("Content script accessible");
+        } else {
+          results.push("Content script returned empty");
+        }
       } else if (resp === null) {
         results.push("Content script unreachable");
       } else {
-        results.push("Content script returned empty");
+        results.push("Invalid content script response");
       }
     } else {
       results.push("No active tab");
@@ -318,32 +335,6 @@ async function runTests() {
   } catch (e) {
     results.push("Error accessing tab");
     debugLog("Content script test error", e);
-  }
-
-  let serverReachable = false;
-  try {
-    const headers = buildAuthHeaders(apiKey, true);
-    log("runTests: health check request", {
-      url: "http://127.0.0.1:5000/health",
-      headers: scrubHeaders(headers),
-    });
-    const health = await fetchWithRetry(
-      "http://127.0.0.1:5000/health",
-      { headers, timeout: 5000 },
-      1
-    );
-    serverReachable = true;
-    log("runTests: health check response", { status: health.status });
-    if (health.status === 200) {
-      results.push("Middleware reachable");
-    } else if (health.status === 401) {
-      results.push("Middleware missing API key");
-    } else {
-      results.push(`Middleware error: ${health.status}`);
-    }
-  } catch (e) {
-    results.push("Middleware unreachable");
-    errorLog("Health check failed", e);
   }
 
   let apiReachable = false;
@@ -406,7 +397,6 @@ async function runTests() {
   const passed =
     apiKeyOk &&
     contentOk &&
-    serverReachable &&
     apiReachable &&
     apiAuthorized &&
     modelsListed;

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -19,8 +19,6 @@
     "default_popup": "popup.html"
   },
   "host_permissions": [
-    "http://127.0.0.1/*",
-    "http://localhost/*",
     "https://api.mistral.ai/*"
   ]
 }


### PR DESCRIPTION
## Summary
- Use Mistral's OCR API directly in the extension instead of a local middleware
- Default to the latest OCR model and only include language when provided to prevent API 422 errors
- Treat empty content-script responses as success and document default model in README

## Testing
- `pytest -q`
- `curl -sS -H 'Authorization: Bearer o7wsum5ynJnXiGocvIkSnXqS0tt05iYX' https://api.mistral.ai/v1/models | head -n 20` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68910f58a0c4832395f37c0f56b134dc