### PR TITLE
Remove local middleware and call Mistral API directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,39 +32,26 @@ A Chrome extension is provided in the `chrome-extension` directory. It can
 save the current tab or a text selection as a file using the Mistral
 OCR service when needed. Markdown, plain text, and JSON outputs are supported.
 
-### Run the local OCR server
-
-```
-pip install flask flask-cors
-python ocr_server.py
-```
-
-The server listens on `http://127.0.0.1:5000`, which the extension uses for
-health checks and OCR requests. The extension transmits the API key only via an
-`Authorization: Bearer` header. The `/health` endpoint validates the key by
-querying the Mistral API's model listing, returning `401`/`403` when the key is
-missing or rejected.
-
 ### Load the extension
 
 1. Open `chrome://extensions` in Chrome and enable **Developer mode**.
 2. Click **Load unpacked** and select the `chrome-extension` folder.
-3. Click the extension icon to open the popup. Enter your API key, preferred
-   model, optional language hint, and desired output format, then click
-   **Save Settings**. The popup shows the extension version at the bottom.
+3. Click the extension icon to open the popup. Enter your API key, optional
+   language hint, desired output format, and (optionally) a model. If no model
+   is specified, the extension uses `mistral-ocr-latest`. Click **Save Settings**
+   when done. The popup shows the extension version at the bottom.
    From the popup you can run **Run Tests** to verify the connection to the
-   content script and local OCR server, and click **Save tab contents as...** to
+   content script and Mistral API, and click **Save tab contents as...** to
    save the active tab or current selection.
 4. Right–click a page or selection and choose **Save Page** or
    **Save Selection** if you prefer using context menus.
 
 The extension stores your API key locally along with the selected model,
-language hint, and output format, and communicates only with the extension's
-background service and the local OCR server.
+language hint, and output format, and communicates only with the Mistral API.
 
 If the page cannot be parsed as HTML (e.g. PDF, image, or office document), the
-extension fetches the complete file and sends it to the local OCR server for
-OCR, ensuring content beyond the visible viewport is processed.
+extension fetches the complete file and sends it to the Mistral OCR API,
+ensuring content beyond the visible viewport is processed.
 
 All configurable options of the OCR API (currently the model and language hint)
 are available in the popup so the user can tailor requests without editing
@@ -74,9 +61,6 @@ source files.
 
 Open the extension popup to enable **Enable debug logging**. When enabled, the
 background service outputs verbose logs (view them via `chrome://extensions`
-→ **Service worker**). The **Run Tests** button now reports separate checks for
-the API key, content script, server reachability, and authorization so it is
-clear which step failed.
-
-Run the OCR server with `python ocr_server.py --debug` to see request headers
-and other diagnostic information.
+→ **Service worker**). The **Run Tests** button reports separate checks for
+the API key, content script, and authorization so it is clear which step
+failed.

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -19,8 +19,6 @@
     "default_popup": "popup.html"
   },
   "host_permissions": [
-    "http://127.0.0.1/*",
-    "http://localhost/*",
     "https://api.mistral.ai/*"
   ]
 }


### PR DESCRIPTION
## Summary
- Use Mistral's OCR API directly in the extension instead of a local middleware
- Default to the latest OCR model and only include language when provided to prevent API 422 errors
- Treat empty content-script responses as success and document default model in README
- Generate downloads via data URLs so the save dialog consistently appears

## Testing
- `pytest -q`
- `curl -sS -H 'Authorization: Bearer o7wsum5ynJnXiGocvIkSnXqS0tt05iYX' https://api.mistral.ai/v1/models | head -n 20` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68910f58a0c4832395f37c0f56b134dc